### PR TITLE
[Flink][Feature]Support task run not by jni call but use velox loop

### DIFF
--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/experimental/stateful/StatefulPlanner.h"
 #include "velox/experimental/stateful/StatefulTask.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/OperatorStats.h"
 
 #include <iostream>
 
@@ -74,6 +76,18 @@ void StatefulTask::initOperators() {
           pool()->treeMemoryUsage());
     }
   }
+}
+
+exec::TaskStats StatefulTask::statefulTaskStats() {
+  exec::TaskStats taskStats;
+  for (auto & op : operators_) {
+    auto statsCopy = op->stats(false);
+    exec::aggregateOperatorRuntimeStats(statsCopy.runtimeStats);
+    exec::PipelineStats pipelineStats(false, false);
+    pipelineStats.operatorStats.emplace_back(statsCopy);
+    taskStats.pipelineStats.emplace_back(pipelineStats);
+  }
+  return taskStats;
 }
 
 RowVectorPtr StatefulTask::next(int32_t& retCode) {

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -15,8 +15,6 @@
  */
 #include "velox/experimental/stateful/StatefulPlanner.h"
 #include "velox/experimental/stateful/StatefulTask.h"
-#include "velox/exec/OperatorUtils.h"
-#include "velox/exec/OperatorStats.h"
 
 #include <iostream>
 
@@ -76,18 +74,6 @@ void StatefulTask::initOperators() {
           pool()->treeMemoryUsage());
     }
   }
-}
-
-exec::TaskStats StatefulTask::statefulTaskStats() {
-  exec::TaskStats taskStats;
-  for (auto & op : operators_) {
-    auto statsCopy = op->stats(false);
-    exec::aggregateOperatorRuntimeStats(statsCopy.runtimeStats);
-    exec::PipelineStats pipelineStats(false, false);
-    pipelineStats.operatorStats.emplace_back(statsCopy);
-    taskStats.pipelineStats.emplace_back(pipelineStats);
-  }
-  return taskStats;
 }
 
 RowVectorPtr StatefulTask::next(int32_t& retCode) {

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -92,7 +92,7 @@ exec::TaskStats StatefulTask::statefulTaskStats() {
 
 RowVectorPtr StatefulTask::next(int32_t& retCode) {
   retCode = 0;
-  initOperators();
+  // initOperators();
 
   // Run operators one by one. If an operator has output, run its downstream operators.
   // If the last operator has output, return the output.
@@ -126,7 +126,8 @@ RowVectorPtr StatefulTask::next(int32_t& retCode) {
           }
           return nullptr;
         } else {
-          break;
+          // break;
+          return nullptr;
         }
       }
 

--- a/velox/experimental/stateful/StatefulTask.h
+++ b/velox/experimental/stateful/StatefulTask.h
@@ -17,7 +17,6 @@
 
 #include "velox/exec/Operator.h"
 #include "velox/exec/Task.h"
-#include "velox/exec/TaskStats.h"
 
 namespace facebook::velox::stateful {
 
@@ -59,9 +58,6 @@ class StatefulTask : public exec::Task {
 
   // The task is finished, close all operators and reset driver
   void finish();
-
-  // get stats for stateful task.
-  exec::TaskStats statefulTaskStats();
 
  private:
  

--- a/velox/experimental/stateful/StatefulTask.h
+++ b/velox/experimental/stateful/StatefulTask.h
@@ -17,6 +17,7 @@
 
 #include "velox/exec/Operator.h"
 #include "velox/exec/Task.h"
+#include "velox/exec/TaskStats.h"
 
 namespace facebook::velox::stateful {
 
@@ -58,6 +59,9 @@ class StatefulTask : public exec::Task {
 
   // The task is finished, close all operators and reset driver
   void finish();
+
+  // get stats for stateful task.
+  exec::TaskStats statefulTaskStats();
 
  private:
  


### PR DESCRIPTION
在过去的实现中， 执行gluten flink 任务， task的运行时通过operator 在执行processElement的时候，逐条的调用jni 通过velox 的task执行来获取结果，性能较差。

此处通过替换该逻辑，通过velox 中C++的单线程的循环代替jni调用，减少性能损失。