### PR TITLE
[Flink][Feature]Add metrics for gluten nexmark support

### DIFF
--- a/velox/experimental/stateful/StatefulOperator.h
+++ b/velox/experimental/stateful/StatefulOperator.h
@@ -71,6 +71,14 @@ class StatefulOperator {
     return operator_->operatorType();
   }
 
+  std::unique_ptr<exec::Operator>& op() {
+    return operator_;
+  }
+
+  std::vector<std::unique_ptr<StatefulOperator>>& targets() {
+    return targets_;
+  }
+
  protected:
   void pushOutput(RowVectorPtr output);
   void pushWatermark(long timestamp, int index);
@@ -78,10 +86,6 @@ class StatefulOperator {
 
   virtual int numInputs() const {
     return 1;
-  }
-
-  std::unique_ptr<exec::Operator>& op() {
-    return operator_;
   }
 
  private:

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/experimental/stateful/StatefulPlanner.h"
 #include "velox/experimental/stateful/StatefulTask.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/OperatorStats.h"
 
 #include <iostream>
 
@@ -74,6 +76,18 @@ void StatefulTask::initOperators() {
           pool()->treeMemoryUsage());
     }
   }
+}
+
+exec::TaskStats StatefulTask::statefulTaskStats() {
+  exec::TaskStats taskStats;
+  for (auto & op : operators_) {
+    auto statsCopy = op->stats(false);
+    exec::aggregateOperatorRuntimeStats(statsCopy.runtimeStats);
+    exec::PipelineStats pipelineStats(false, false);
+    pipelineStats.operatorStats.emplace_back(statsCopy);
+    taskStats.pipelineStats.emplace_back(pipelineStats);
+  }
+  return taskStats;
 }
 
 RowVectorPtr StatefulTask::next(int32_t& retCode) {

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -19,8 +19,6 @@
 #include "velox/exec/OperatorStats.h"
 #include "velox/experimental/stateful/state/HashMapStateBackend.h"
 
-#include <iostream>
-
 namespace facebook::velox::stateful {
 
 // static
@@ -77,15 +75,21 @@ void StatefulTask::initOperators() {
       std::move(StatefulPlanner::plan(planFragment(), driver->driverCtx(), statebackend_.get()));
 }
 
+void statefulTaskStatus(exec::TaskStats& taskStats, const std::unique_ptr<StatefulOperator>& statefulOp) {
+  auto statsCopy = statefulOp->op()->stats(false);
+  exec::aggregateOperatorRuntimeStats(statsCopy.runtimeStats);
+  exec::PipelineStats pipelineStats(false, false);
+  pipelineStats.operatorStats.emplace_back(statsCopy);
+  taskStats.pipelineStats.emplace_back(pipelineStats);
+  std::vector<std::unique_ptr<StatefulOperator>>& targets = statefulOp->targets();
+  for (const auto& target : targets) {
+    statefulTaskStatus(taskStats, target);
+  }
+}
+
 exec::TaskStats StatefulTask::statefulTaskStats() {
   exec::TaskStats taskStats;
-  for (auto & op : operators_) {
-    auto statsCopy = op->stats(false);
-    exec::aggregateOperatorRuntimeStats(statsCopy.runtimeStats);
-    exec::PipelineStats pipelineStats(false, false);
-    pipelineStats.operatorStats.emplace_back(statsCopy);
-    taskStats.pipelineStats.emplace_back(pipelineStats);
-  }
+  statefulTaskStatus(taskStats, operatorChain_);
   return taskStats;
 }
 

--- a/velox/experimental/stateful/StatefulTask.h
+++ b/velox/experimental/stateful/StatefulTask.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include "velox/exec/Operator.h"
 #include "velox/exec/Task.h"
 #include "velox/exec/TaskStats.h"
 #include "velox/experimental/stateful/StatefulOperator.h"

--- a/velox/experimental/stateful/StatefulTask.h
+++ b/velox/experimental/stateful/StatefulTask.h
@@ -17,6 +17,7 @@
 
 #include "velox/exec/Operator.h"
 #include "velox/exec/Task.h"
+#include "velox/exec/TaskStats.h"
 
 namespace facebook::velox::stateful {
 
@@ -58,6 +59,9 @@ class StatefulTask : public exec::Task {
 
   // The task is finished, close all operators and reset driver
   void finish();
+
+  // get stats for stateful task.
+  exec::TaskStats statefulTaskStats();
 
  private:
  


### PR DESCRIPTION
通过nexmark 测试gluten，需要获取算子的单位时间内处理的数据条数，从而判断任务有没有执行完，这里返回velox中的operator stats，在gluten flink中统计metric，用于nexmark 测试。