### PR TITLE
[FLINK][BUG]Fix dead loop while source/sink operator has streaming i/o

### DIFF
--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -109,24 +109,22 @@ StreamElementPtr StatefulTask::next(int32_t& retCode) {
   // If source operator has no output, check whether it is finished.
   // If source is finished, return null and 1 for rerCode, else return null and 0 for retCode.
   // TODO: only support operators in a sequence mode.
-  for (;;) {
-    VELOX_CHECK_EQ(
-        state(), exec::TaskState::kRunning, "Task has already finished processing.");
+  VELOX_CHECK_EQ(
+      state(), exec::TaskState::kRunning, "Task has already finished processing.");
 
-    operatorChain_->getOutput();
-    if (pendings_.empty()) {
-      if (operatorChain_->isFinished()) {
-        finish();
-        // finish may trigger window flush and generate output.
-        if (pendings_.empty()) {
-          retCode = 1;
-          return nullptr;
-        }
-      } else if (operatorChain_->sourceEmpty()) {
-        return nullptr;
-      } else {
+  operatorChain_->getOutput();
+  if (pendings_.empty()) {
+    if (operatorChain_->isFinished()) {
+      finish();
+      // finish may trigger window flush and generate output.
+      if (pendings_.empty()) {
+        retCode = 1;
         return nullptr;
       }
+    } else if (operatorChain_->sourceEmpty()) {
+      return nullptr;
+    } else {
+      return nullptr;
     }
     return std::move(popOutput());
   }

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -87,41 +87,39 @@ RowVectorPtr StatefulTask::next(int32_t& retCode) {
   // TODO: only support operators in a sequence mode.
   const auto numOperators = operators_.size();
 
-  for (;;) {
-    VELOX_CHECK_EQ(
-        state(), exec::TaskState::kRunning, "Task has already finished processing.");
+  VELOX_CHECK_EQ(
+      state(), exec::TaskState::kRunning, "Task has already finished processing.");
 
-    for (auto i = 0; i < numOperators; ++i) {
-      auto op = operators_[i].get();
-      auto intermediateResult = op->getOutput();
-      if (intermediateResult) {
-        if (i == numOperators - 1) {
-          return intermediateResult;
-        } else {
-          auto nextOp = operators_[i + 1].get();
-          nextOp->traceInput(intermediateResult);
-          nextOp->addInput(intermediateResult);
-        }
+  for (auto i = 0; i < numOperators; ++i) {
+    auto op = operators_[i].get();
+    auto intermediateResult = op->getOutput();
+    if (intermediateResult) {
+      if (i == numOperators - 1) {
+        return intermediateResult;
       } else {
-        // Source operator has no result
-        if (i == 0) {
-          // TODO: when source is finished, maybe other operators need to do something.
-          if (op->isFinished()) {
-            retCode = 1;
-            finish();
-          }
-          return nullptr;
-        } else {
-          break;
-        }
+        auto nextOp = operators_[i + 1].get();
+        nextOp->traceInput(intermediateResult);
+        nextOp->addInput(intermediateResult);
       }
-
-    }
-
-    if (error()) {
-      std::rethrow_exception(error());
+    } else {
+      // Source operator has no result
+      if (i == 0) {
+        // TODO: when source is finished, maybe other operators need to do something.
+        if (op->isFinished()) {
+          retCode = 1;
+          finish();
+        }
+        return nullptr;
+      } else {
+        break;
+      }
     }
   }
+
+  if (error()) {
+    std::rethrow_exception(error());
+  }
+  return nullptr;
 }
 
 void StatefulTask::finish() {


### PR DESCRIPTION
当消费source 数据，写入到DiscardSink中，DiscardSink 返回`nullptr`，导致在StatefulTask.cpp进入一个死循环中。

如果此时gluten中 触发作业的cancel，由于velox中处理死循环中，将导致任务无法被cancel，如果强制停止，则会导致作业停止的过程中出现资源泄漏。

修复方法：移除外层for(; ;) 循环， 防止进入死循环