### PR TITLE
[FLINK]Fix timestamp read should respect timezone

### DIFF
--- a/velox/connectors/from_elements/FromElementsSource.cpp
+++ b/velox/connectors/from_elements/FromElementsSource.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/connectors/from_elements/FromElementsSource.h"
-#include <type/tz/TimeZoneMap.h>
+#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::connector::from_elements {

--- a/velox/connectors/from_elements/FromElementsSource.cpp
+++ b/velox/connectors/from_elements/FromElementsSource.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/connectors/from_elements/FromElementsSource.h"
+#include <type/tz/TimeZoneMap.h>
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::connector::from_elements {
@@ -25,7 +26,7 @@ FromElementsSource::FromElementsSource(
   const std::vector<std::string>& s)
     : outputType_(outputType),
     queryCtx_(queryCtx),
-    formatter_(createFormatter(outputType)) {
+    formatter_(createFormatter(outputType, tz::locateZone(queryCtx->sessionTimezone()))) {
       VELOX_CHECK(formatter_ != nullptr);
       auto row = RowVector::createEmpty(outputType_, queryCtx->memoryPool());
       row->resize(s.size());

--- a/velox/connectors/print/PrintSink.cpp
+++ b/velox/connectors/print/PrintSink.cpp
@@ -16,8 +16,8 @@
 #include "velox/connectors/print/PrintSink.h"
 #include "velox/dwio/common/WriterFactory.h"
 #include "velox/type/Type.h"
+#include "velox/type/tz/TimeZoneMap.h"
 #include <fmt/format.h>
-#include <type/tz/TimeZoneMap.h>
 #include <memory>
 
 namespace facebook::velox::connector::print {

--- a/velox/connectors/print/PrintSink.cpp
+++ b/velox/connectors/print/PrintSink.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/common/WriterFactory.h"
 #include "velox/type/Type.h"
 #include <fmt/format.h>
+#include <type/tz/TimeZoneMap.h>
 #include <memory>
 
 namespace facebook::velox::connector::print {
@@ -29,7 +30,7 @@ PrintSink::PrintSink(
       outputType_(createOutputType()),
       queryCtx_(queryCtx),
       writer_(createWriter(path)),
-      formatter_(createFormatter(inputType_)) {}
+      formatter_(createFormatter(inputType_, tz::locateZone(queryCtx->sessionTimezone()))) {}
 
 std::unique_ptr<dwio::common::Writer> PrintSink::createWriter(
     const std::string& path) {

--- a/velox/connectors/utils/StringFormatter.cpp
+++ b/velox/connectors/utils/StringFormatter.cpp
@@ -17,7 +17,6 @@
 #include "velox/connectors/utils/StringFormatter.h"
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <type/tz/TimeZoneMap.h>
 #include <stack>
 
 namespace facebook::velox::connector {

--- a/velox/connectors/utils/StringFormatter.cpp
+++ b/velox/connectors/utils/StringFormatter.cpp
@@ -17,37 +17,38 @@
 #include "velox/connectors/utils/StringFormatter.h"
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <type/tz/TimeZoneMap.h>
 #include <stack>
 
 namespace facebook::velox::connector {
-const FormatterPtr createFormatter(const TypePtr& type) {
+const FormatterPtr createFormatter(const TypePtr& type, const tz::TimeZone* timeZone) {
   TypeKind typeKind = type->kind();
   switch (typeKind) {
     case TypeKind::INTEGER:
-      return std::make_shared<DefaultFormatter<int32_t>>();
+      return std::make_shared<DefaultFormatter<int32_t>>(timeZone);
     case TypeKind::BIGINT:
-      return std::make_shared<DefaultFormatter<int64_t>>();
+      return std::make_shared<DefaultFormatter<int64_t>>(timeZone);
     case TypeKind::HUGEINT:
-      return std::make_shared<DefaultFormatter<int128_t>>();
+      return std::make_shared<DefaultFormatter<int128_t>>(timeZone);
     case TypeKind::SMALLINT:
-      return std::make_shared<DefaultFormatter<int16_t>>();
+      return std::make_shared<DefaultFormatter<int16_t>>(timeZone);
     case TypeKind::TINYINT:
-      return std::make_shared<DefaultFormatter<int8_t>>();
+      return std::make_shared<DefaultFormatter<int8_t>>(timeZone);
     case TypeKind::DOUBLE:
-      return std::make_shared<DefaultFormatter<double>>();
+      return std::make_shared<DefaultFormatter<double>>(timeZone);
     case TypeKind::REAL:
-      return std::make_shared<DefaultFormatter<float>>();
+      return std::make_shared<DefaultFormatter<float>>(timeZone);
     case TypeKind::BOOLEAN:
-      return std::make_shared<DefaultFormatter<bool>>();
+      return std::make_shared<DefaultFormatter<bool>>(timeZone);
     case TypeKind::VARCHAR:
-      return std::make_shared<DefaultFormatter<StringView>>();
+      return std::make_shared<DefaultFormatter<StringView>>(timeZone);
     case TypeKind::TIMESTAMP:
-      return std::make_shared<DefaultFormatter<Timestamp>>();
+      return std::make_shared<DefaultFormatter<Timestamp>>(timeZone);
     case TypeKind::ROW: {
       const RowTypePtr rowType = std::dynamic_pointer_cast<const RowType>(type);
       std::vector<FormatterPtr> formatters;
       for (size_t i = 0; i < rowType->children().size(); ++i) {
-        const auto formatter = createFormatter(rowType->childAt(i));
+        const auto formatter = createFormatter(rowType->childAt(i), timeZone);
         formatters.emplace_back(formatter);
       }
       return std::make_shared<RowFormatter>(formatters);
@@ -56,7 +57,7 @@ const FormatterPtr createFormatter(const TypePtr& type) {
       const std::shared_ptr<const ArrayType> arrayType =
           std::dynamic_pointer_cast<const ArrayType>(type);
       const TypePtr& elementType = arrayType->elementType();
-      auto elemmentFormatter = createFormatter(elementType);
+      auto elemmentFormatter = createFormatter(elementType, timeZone);
       return std::make_shared<ArrayFormatter>(elemmentFormatter);
     }
     case TypeKind::MAP: {
@@ -64,8 +65,8 @@ const FormatterPtr createFormatter(const TypePtr& type) {
           std::dynamic_pointer_cast<const MapType>(type);
       const TypePtr& keyType = mapType->keyType();
       const TypePtr& valueType = mapType->valueType();
-      auto keyFormatter = createFormatter(keyType);
-      auto valueFormatter = createFormatter(valueType);
+      auto keyFormatter = createFormatter(keyType, timeZone);
+      auto valueFormatter = createFormatter(valueType, timeZone);
       return std::make_shared<MapFormatter>(
           keyFormatter, valueFormatter);
     }

--- a/velox/connectors/utils/StringFormatter.h
+++ b/velox/connectors/utils/StringFormatter.h
@@ -161,18 +161,7 @@ struct DefaultFormatter : public StringFormatter {
     } else if constexpr (std::is_same_v<T, StringView>) {
       ss << t.str();
     } else if constexpr (std::is_same_v<T, Timestamp>) {
-      TimestampToStringOptions options;
-      uint64_t nanos = t.getNanos();
-      if (nanos % 1000 != 0) {
-        options.precision = TimestampPrecision::kNanoseconds;
-      } else if ((nanos / 1000) % 1000 != 0) {
-        options.precision = TimestampPrecision::kMicroseconds;
-      } else if ((nanos / 1000000) % 1000 != 0) {
-        options.precision = TimestampPrecision::kMilliseconds;
-      } else {
-        options.skipTrailingZeros = true;
-      }
-      ss << t.toString(options);
+      ss << t.toString();
     } else {
       VELOX_FAIL("Not supported type: {}", typeid(T).name());
     }

--- a/velox/connectors/utils/StringFormatter.h
+++ b/velox/connectors/utils/StringFormatter.h
@@ -161,7 +161,8 @@ struct DefaultFormatter : public StringFormatter {
     } else if constexpr (std::is_same_v<T, StringView>) {
       ss << t.str();
     } else if constexpr (std::is_same_v<T, Timestamp>) {
-      ss << t.toString();
+      TimestampToStringOptions options{.precision=TimestampPrecision::kMilliseconds};
+      ss << t.toString(options);
     } else {
       VELOX_FAIL("Not supported type: {}", typeid(T).name());
     }

--- a/velox/connectors/utils/StringFormatter.h
+++ b/velox/connectors/utils/StringFormatter.h
@@ -147,7 +147,18 @@ struct DefaultFormatter : public StringFormatter {
     } else if constexpr (std::is_same_v<T, StringView>) {
       ss << t.str();
     } else if constexpr (std::is_same_v<T, Timestamp>) {
-      ss << t.toString();
+      TimestampToStringOptions options;
+      uint64_t nanos = t.getNanos();
+      if (nanos % 1000 != 0) {
+        options.precision = TimestampPrecision::kNanoseconds;
+      } else if ((nanos / 1000) % 1000 != 0) {
+        options.precision = TimestampPrecision::kMicroseconds;
+      } else if ((nanos / 1000000) % 1000 != 0) {
+        options.precision = TimestampPrecision::kMilliseconds;
+      } else {
+        options.skipTrailingZeros = true;
+      }
+      ss << t.toString(options);
     } else {
       VELOX_FAIL("Not supported type: {}", typeid(T).name());
     }

--- a/velox/connectors/utils/StringFormatter.h
+++ b/velox/connectors/utils/StringFormatter.h
@@ -211,11 +211,7 @@ struct DefaultFormatter : public StringFormatter {
         .thenOrThrow(folly::identity, [&](const Status& status) {
               VELOX_FAIL("error while parse timestamp: {}", status.message());
         });
-      auto timestamp =  util::fromParsedTimestampWithTimeZone(parsed, timeZone_);
-      if (timeZone_) {
-        timestamp.toTimezone(*timeZone_);
-      }
-      return timestamp;
+      return util::fromParsedTimestampWithTimeZone(parsed, timeZone_);
     } else {
       VELOX_FAIL("Not supported type: {}", typeid(T).name());
     }

--- a/velox/connectors/utils/StringFormatter.h
+++ b/velox/connectors/utils/StringFormatter.h
@@ -19,6 +19,7 @@
 #include "velox/type/StringView.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/TimestampConversion.h"
+#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ComplexVector.h"
 #include <boost/algorithm/string.hpp>
@@ -26,13 +27,21 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <folly/Try.h>
+#include <ctime>
 #include <memory>
+#include <string>
 #include <type_traits>
+#include <iostream>
 
 namespace facebook::velox::connector {
 
 struct StringFormatter {
  public:
+  StringFormatter(const tz::TimeZone* timeZone) : timeZone_(timeZone) {
+    VELOX_CHECK(timeZone_ != nullptr);
+  }
+  StringFormatter() : timeZone_(tz::locateZone("UTC")) {}
+
   virtual const void toString(
       const VectorPtr& input,
       const TypePtr&,
@@ -52,6 +61,9 @@ struct StringFormatter {
       const std::string& delimiter);
   /// Normalize the input string of flink-style to make it easy to be splitted. e.g. +I[1,2,3] -> 1,2,3.
   static const void normalize(std::string& s, const TypeKind kind);
+
+  protected:
+    const tz::TimeZone* timeZone_;
 };
 
 using FormatterPtr = std::shared_ptr<StringFormatter>;
@@ -59,6 +71,9 @@ using FormatterPtr = std::shared_ptr<StringFormatter>;
 template <typename T>
 struct DefaultFormatter : public StringFormatter {
  public:
+  DefaultFormatter(const tz::TimeZone* timeZone) : StringFormatter(timeZone) {}
+  DefaultFormatter() : StringFormatter() {}
+
   const void toString(
       const VectorPtr& input,
       const TypePtr& type,
@@ -192,12 +207,15 @@ struct DefaultFormatter : public StringFormatter {
       StringView sv(s.data(), s.size());
       return sv;
     } else if constexpr (std::is_same_v<T, Timestamp>) {
-      const auto timestamp =
-          util::fromTimestampString(
-              s.data(), s.size(), util::TimestampParseMode::kLegacyCast)
-              .thenOrThrow(folly::identity, [&](const Status& status) {
-                VELOX_FAIL("error while parse timestamp: {}", status.message());
-              });
+      const auto parsed =
+        util::fromTimestampWithTimezoneString(s.data(), s.size(), util::TimestampParseMode::kLegacyCast)
+        .thenOrThrow(folly::identity, [&](const Status& status) {
+              VELOX_FAIL("error while parse timestamp: {}", status.message());
+        });
+      auto timestamp =  util::fromParsedTimestampWithTimeZone(parsed, timeZone_);
+      if (timeZone_) {
+        timestamp.toTimezone(*timeZone_);
+      }
       return timestamp;
     } else {
       VELOX_FAIL("Not supported type: {}", typeid(T).name());
@@ -405,6 +423,6 @@ struct MapFormatter : public StringFormatter {
   FormatterPtr valueFormatter_;
 };
 
-const FormatterPtr createFormatter(const TypePtr& type);
+const FormatterPtr createFormatter(const TypePtr& type, const tz::TimeZone* timeZone);
 
 } // namespace facebook::velox::stateful

--- a/velox/connectors/utils/StringFormatter.h
+++ b/velox/connectors/utils/StringFormatter.h
@@ -31,7 +31,6 @@
 #include <memory>
 #include <string>
 #include <type_traits>
-#include <iostream>
 
 namespace facebook::velox::connector {
 

--- a/velox/connectors/utils/tests/StringFormatterTest.cpp
+++ b/velox/connectors/utils/tests/StringFormatterTest.cpp
@@ -103,7 +103,7 @@ TEST_F(StringFormatterTest, testTimestampToString) {
   vec->asFlatVector<Timestamp>()->set(6, toTimestamp(s6));
   vec->asFlatVector<Timestamp>()->set(7, toTimestamp(s7));
   DefaultFormatter<Timestamp> formatter;
-  for (int i = 0; i < 5; ++i) {
+  for (int i = 0; i < 8; ++i) {
     std::stringstream ss;
     formatter.toString(vec, timestampType, i, ss);
     if (i == 0) {

--- a/velox/connectors/utils/tests/StringFormatterTest.cpp
+++ b/velox/connectors/utils/tests/StringFormatterTest.cpp
@@ -126,6 +126,50 @@ TEST_F(StringFormatterTest, testTimestampToString) {
   }
 }
 
+TEST_F(StringFormatterTest, testStringToTimestamp) {
+  DefaultFormatter<Timestamp> formatter;
+  TypePtr timestampType = std::make_shared<TimestampType>();
+  VectorPtr vec = FlatVector<Timestamp>::create(timestampType, 3, memoryPool.get());
+  formatter.fromString("2025-09-08T19:14:12", timestampType, 0, vec);
+  formatter.fromString("2025-09-08T19:14:12.100", timestampType, 1, vec);
+  formatter.fromString("2025-09-08T19:14:12Z", timestampType, 2, vec);
+  TimestampToStringOptions options{.skipTrailingZeros=true};
+  std::string s0 = vec->asFlatVector<Timestamp>()->valueAt(0).toString(options);
+  std::string s1 = vec->asFlatVector<Timestamp>()->valueAt(1).toString(options);
+  std::string s2 = vec->asFlatVector<Timestamp>()->valueAt(2).toString(options);
+  ASSERT_TRUE(s0 == "2025-09-08T19:14:12");
+  ASSERT_TRUE(s1 == "2025-09-08T19:14:12.1");
+  ASSERT_TRUE(s2 == "2025-09-08T19:14:12");
+  DefaultFormatter<Timestamp> formatter0(tz::locateZone("America/Los_Angeles"));
+  VectorPtr vec0 = FlatVector<Timestamp>::create(timestampType, 2, memoryPool.get());
+  formatter0.fromString("2025-09-08T19:14:12Z", timestampType, 0, vec0);
+  formatter0.fromString("2025-09-08T19:14:12.100Z", timestampType, 1, vec0);
+  std::string s3 = vec0->asFlatVector<Timestamp>()->valueAt(0).toString(options);
+  std::string s4 = vec0->asFlatVector<Timestamp>()->valueAt(1).toString(options);
+  ASSERT_TRUE(s3 == "2025-09-08T12:14:12");
+  ASSERT_TRUE(s4 == "2025-09-08T12:14:12.1");
+  DefaultFormatter<Timestamp> formatter1(tz::locateZone("Asia/Shanghai"));
+  VectorPtr vec1 = FlatVector<Timestamp>::create(timestampType, 6, memoryPool.get());;
+  formatter1.fromString("2025-09-08T19:14:12America/Los_Angeles", timestampType, 0, vec1);
+  formatter1.fromString("2025-09-08T19:14:12.1Z", timestampType, 1, vec1);
+  formatter1.fromString("2025-09-08T19:14:12+03:00", timestampType, 2, vec1);
+  formatter1.fromString("2025-09-08T19:14:12-03:00", timestampType, 3, vec1);
+  formatter1.fromString("2025-09-08T19:14:12+03:15", timestampType, 4, vec1);
+  formatter1.fromString("2025-09-08T19:14:12-03:15", timestampType, 5, vec1);
+  std::string s5 = vec1->asFlatVector<Timestamp>()->valueAt(0).toString(options);
+  std::string s6 = vec1->asFlatVector<Timestamp>()->valueAt(1).toString(options);
+  std::string s7 = vec1->asFlatVector<Timestamp>()->valueAt(2).toString(options);
+  std::string s8 = vec1->asFlatVector<Timestamp>()->valueAt(3).toString(options);
+  std::string s9 = vec1->asFlatVector<Timestamp>()->valueAt(4).toString(options);
+  std::string s10 = vec1->asFlatVector<Timestamp>()->valueAt(5).toString(options);
+  ASSERT_TRUE(s5 == "2025-09-09T10:14:12");
+  ASSERT_TRUE(s6 == "2025-09-09T03:14:12.1");
+  ASSERT_TRUE(s7 == "2025-09-09T00:14:12");
+  ASSERT_TRUE(s8 == "2025-09-09T06:14:12");
+  ASSERT_TRUE(s9 == "2025-09-08T23:59:12");
+  ASSERT_TRUE(s10 == "2025-09-09T06:29:12");
+}
+
 } // namespace facebook::velox::stateful::test
 
 int main(int argc, char* argv[]) {

--- a/velox/connectors/utils/tests/StringFormatterTest.cpp
+++ b/velox/connectors/utils/tests/StringFormatterTest.cpp
@@ -142,12 +142,12 @@ TEST_F(StringFormatterTest, testStringToTimestamp) {
   ASSERT_TRUE(s2 == "2025-09-08T19:14:12");
   DefaultFormatter<Timestamp> formatter0(tz::locateZone("America/Los_Angeles"));
   VectorPtr vec0 = FlatVector<Timestamp>::create(timestampType, 2, memoryPool.get());
-  formatter0.fromString("2025-09-08T19:14:12Z", timestampType, 0, vec0);
-  formatter0.fromString("2025-09-08T19:14:12.100Z", timestampType, 1, vec0);
+  formatter0.fromString("2025-09-08T19:14:12", timestampType, 0, vec0);
+  formatter0.fromString("2025-09-08T19:14:12.100", timestampType, 1, vec0);
   std::string s3 = vec0->asFlatVector<Timestamp>()->valueAt(0).toString(options);
   std::string s4 = vec0->asFlatVector<Timestamp>()->valueAt(1).toString(options);
-  ASSERT_TRUE(s3 == "2025-09-08T12:14:12");
-  ASSERT_TRUE(s4 == "2025-09-08T12:14:12.1");
+  ASSERT_TRUE(s3 == "2025-09-09T02:14:12");
+  ASSERT_TRUE(s4 == "2025-09-09T02:14:12.1");
   DefaultFormatter<Timestamp> formatter1(tz::locateZone("Asia/Shanghai"));
   VectorPtr vec1 = FlatVector<Timestamp>::create(timestampType, 6, memoryPool.get());;
   formatter1.fromString("2025-09-08T19:14:12America/Los_Angeles", timestampType, 0, vec1);
@@ -162,12 +162,12 @@ TEST_F(StringFormatterTest, testStringToTimestamp) {
   std::string s8 = vec1->asFlatVector<Timestamp>()->valueAt(3).toString(options);
   std::string s9 = vec1->asFlatVector<Timestamp>()->valueAt(4).toString(options);
   std::string s10 = vec1->asFlatVector<Timestamp>()->valueAt(5).toString(options);
-  ASSERT_TRUE(s5 == "2025-09-09T10:14:12");
-  ASSERT_TRUE(s6 == "2025-09-09T03:14:12.1");
-  ASSERT_TRUE(s7 == "2025-09-09T00:14:12");
-  ASSERT_TRUE(s8 == "2025-09-09T06:14:12");
-  ASSERT_TRUE(s9 == "2025-09-08T23:59:12");
-  ASSERT_TRUE(s10 == "2025-09-09T06:29:12");
+  ASSERT_TRUE(s5 == "2025-09-09T02:14:12");
+  ASSERT_TRUE(s6 == "2025-09-08T19:14:12.1");
+  ASSERT_TRUE(s7 == "2025-09-08T16:14:12");
+  ASSERT_TRUE(s8 == "2025-09-08T22:14:12");
+  ASSERT_TRUE(s9 == "2025-09-08T15:59:12");
+  ASSERT_TRUE(s10 == "2025-09-08T22:29:12");
 }
 
 } // namespace facebook::velox::stateful::test

--- a/velox/connectors/utils/tests/StringFormatterTest.cpp
+++ b/velox/connectors/utils/tests/StringFormatterTest.cpp
@@ -19,6 +19,7 @@
 
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
+#include <iostream>
 
 namespace facebook::velox::connector::test {
 
@@ -74,6 +75,56 @@ TEST_F(StringFormatterTest, testSplit) {
   ASSERT_TRUE(ss3[1] == "[+I[1,2],+I[3,4]]");
   std::vector<std::string> ss4 = StringFormatter::split(s4, ",");
   ASSERT_TRUE(ss4.size() == 2);
+}
+
+TEST_F(StringFormatterTest, testTimestampToString) {
+  auto toTimestamp = [&](const std::string& s) -> Timestamp {
+    return util::fromTimestampString(
+      s.data(), s.size(), util::TimestampParseMode::kSparkCast)
+      .thenOrThrow(folly::identity, [&](const Status& status) {
+        VELOX_FAIL("error while parse timestamp: {}", status.message());
+      });
+  };
+  std::string s0 = "2025-09-08 19:14:12";
+  std::string s1 = "2025-09-08 19:14:12.001";
+  std::string s2 = "2025-09-08 19:14:12.300";
+  std::string s3 = "2025-09-08 19:14:12.300100";
+  std::string s4 = "2025-09-08 19:14:12.300100200";
+  std::string s5 = "2025-09-08 19:14:12.000";
+  std::string s6 = "2025-09-08 19:14:12.3";
+  std::string s7 = "2025-09-08 19:14:12.31";
+  TypePtr timestampType = std::make_shared<TimestampType>();
+  VectorPtr vec = FlatVector<Timestamp>::create(timestampType, 8, memoryPool.get());
+  vec->asFlatVector<Timestamp>()->set(0, toTimestamp(s0));
+  vec->asFlatVector<Timestamp>()->set(1, toTimestamp(s1));
+  vec->asFlatVector<Timestamp>()->set(2, toTimestamp(s2));
+  vec->asFlatVector<Timestamp>()->set(3, toTimestamp(s3));
+  vec->asFlatVector<Timestamp>()->set(4, Timestamp::fromNanos(toTimestamp(s4).toMicros() * 1000 + 200));
+  vec->asFlatVector<Timestamp>()->set(5, toTimestamp(s5));
+  vec->asFlatVector<Timestamp>()->set(6, toTimestamp(s6));
+  vec->asFlatVector<Timestamp>()->set(7, toTimestamp(s7));
+  DefaultFormatter<Timestamp> formatter;
+  for (int i = 0; i < 5; ++i) {
+    std::stringstream ss;
+    formatter.toString(vec, timestampType, i, ss);
+    if (i == 0) {
+      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12");
+    } else if (i == 1) {
+      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.001");
+    } else if (i == 2) {
+      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.300");
+    } else if (i == 3) {
+      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.300100");
+    } else if (i == 4) {
+      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.300100200");
+    } else if (i == 5) {
+      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12");
+    } else if (i == 6) {
+      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.300");
+    } else if (i == 7) {
+      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.310");
+    }
+  }
 }
 
 } // namespace facebook::velox::stateful::test

--- a/velox/connectors/utils/tests/StringFormatterTest.cpp
+++ b/velox/connectors/utils/tests/StringFormatterTest.cpp
@@ -76,56 +76,6 @@ TEST_F(StringFormatterTest, testSplit) {
   ASSERT_TRUE(ss4.size() == 2);
 }
 
-TEST_F(StringFormatterTest, testTimestampToString) {
-  auto toTimestamp = [&](const std::string& s) -> Timestamp {
-    return util::fromTimestampString(
-      s.data(), s.size(), util::TimestampParseMode::kSparkCast)
-      .thenOrThrow(folly::identity, [&](const Status& status) {
-        VELOX_FAIL("error while parse timestamp: {}", status.message());
-      });
-  };
-  std::string s0 = "2025-09-08 19:14:12";
-  std::string s1 = "2025-09-08 19:14:12.001";
-  std::string s2 = "2025-09-08 19:14:12.300";
-  std::string s3 = "2025-09-08 19:14:12.300100";
-  std::string s4 = "2025-09-08 19:14:12.300100200";
-  std::string s5 = "2025-09-08 19:14:12.000";
-  std::string s6 = "2025-09-08 19:14:12.3";
-  std::string s7 = "2025-09-08 19:14:12.31";
-  TypePtr timestampType = std::make_shared<TimestampType>();
-  VectorPtr vec = FlatVector<Timestamp>::create(timestampType, 8, memoryPool.get());
-  vec->asFlatVector<Timestamp>()->set(0, toTimestamp(s0));
-  vec->asFlatVector<Timestamp>()->set(1, toTimestamp(s1));
-  vec->asFlatVector<Timestamp>()->set(2, toTimestamp(s2));
-  vec->asFlatVector<Timestamp>()->set(3, toTimestamp(s3));
-  vec->asFlatVector<Timestamp>()->set(4, Timestamp::fromNanos(toTimestamp(s4).toMicros() * 1000 + 200));
-  vec->asFlatVector<Timestamp>()->set(5, toTimestamp(s5));
-  vec->asFlatVector<Timestamp>()->set(6, toTimestamp(s6));
-  vec->asFlatVector<Timestamp>()->set(7, toTimestamp(s7));
-  DefaultFormatter<Timestamp> formatter;
-  for (int i = 0; i < 8; ++i) {
-    std::stringstream ss;
-    formatter.toString(vec, timestampType, i, ss);
-    if (i == 0) {
-      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12");
-    } else if (i == 1) {
-      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.001");
-    } else if (i == 2) {
-      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.300");
-    } else if (i == 3) {
-      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.300100");
-    } else if (i == 4) {
-      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.300100200");
-    } else if (i == 5) {
-      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12");
-    } else if (i == 6) {
-      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.300");
-    } else if (i == 7) {
-      ASSERT_TRUE(ss.str() == "2025-09-08T19:14:12.310");
-    }
-  }
-}
-
 TEST_F(StringFormatterTest, testStringToTimestamp) {
   DefaultFormatter<Timestamp> formatter;
   TypePtr timestampType = std::make_shared<TimestampType>();

--- a/velox/connectors/utils/tests/StringFormatterTest.cpp
+++ b/velox/connectors/utils/tests/StringFormatterTest.cpp
@@ -19,7 +19,6 @@
 
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
-#include <iostream>
 
 namespace facebook::velox::connector::test {
 

--- a/velox/connectors/utils/tests/StringFormatterTest.h
+++ b/velox/connectors/utils/tests/StringFormatterTest.h
@@ -21,8 +21,15 @@ namespace facebook::velox::connector::test {
 
 class StringFormatterTestBase : public exec::test::OperatorTestBase {
  public:
-  void SetUp() override {}
-  void TearDown() override {}
+  const std::shared_ptr<memory::MemoryPool> memoryPool = memory::memoryManager()->addLeafPool();
+
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+  }
+
+  void TearDown() override {
+    OperatorTestBase::TearDown();
+  }
 };
 
 } // namespace facebook::velox::stateful::test

--- a/velox/external/tzdb/tzdb.cpp
+++ b/velox/external/tzdb/tzdb.cpp
@@ -724,8 +724,7 @@ static void __parse_link(tzdb& __tzdb, std::istream& __input) {
   __tzdb.links.emplace_back(std::move(__name), std::move(__target));
 }
 
-template <int recordType>
-static void __parse_tzdata_record_type(
+static void __parse_tzdata(
     tzdb& __db,
     __rules_storage_type& __rules,
     std::istream& __input) {
@@ -746,55 +745,24 @@ static void __parse_tzdata_record_type(
         break;
 
       case 'r':
-        if constexpr (recordType == 'r') {
-          __skip(__input, "ule");
-          __parse_rule(__db, __rules, __input);
-        } else {
-          __skip_line(__input);
-        }
+        __skip(__input, "ule");
+        __parse_rule(__db, __rules, __input);
         break;
 
-      case 'l':
-        if constexpr (recordType == 'l') {
-          __skip(__input, "ink");
-          __parse_link(__db, __input);
-        } else {
-          __skip_line(__input);
-        }
+      case 'z':
+        __skip(__input, "one");
+        __parse_zone(__db, __rules, __input);
         break;
       
-      case 'z':
-        if constexpr (recordType == 'z') {
-          __skip(__input, "one");
-          __parse_zone(__db, __rules, __input);
-        } else {
-          __skip_line(__input);
-        }
+      case 'l':
+        __skip(__input, "ink");
+        __parse_link(__db, __input);
         break;
 
       default:
-        if constexpr (recordType == 'z') {
-          // Only z (Zones) have continuation lines.
-          // When parsing z, any token not matched by the earlier cases is invalid.
-          // (continuations are consumed inside __parse_zone)
-          std::__throw_runtime_error("corrupt tzdb: unexpected input");
-        } else {
-          __skip_line(__input);
-        }
+        std::__throw_runtime_error("corrupt tzdb: unexpected input");
     }
   }
-}
-
-static void __parse_tzdata(
-    tzdb& __db,
-    __rules_storage_type& __rules,
-    std::istream& __input) {
-  // Parse tzdata.zi in order: Rules → Zones → Links.
-  // Zones may reference Rules; Links alias Zones.
-  const std::string buf{std::istreambuf_iterator<char>(__input), {}};
-  { std::istringstream iss(buf); __parse_tzdata_record_type<'r'>(__db, __rules, iss); }
-  { std::istringstream iss(buf); __parse_tzdata_record_type<'z'>(__db, __rules, iss); }
-  { std::istringstream iss(buf); __parse_tzdata_record_type<'l'>(__db, __rules, iss); }
 }
 
 static void __parse_leap_seconds(

--- a/velox/external/tzdb/tzdb.cpp
+++ b/velox/external/tzdb/tzdb.cpp
@@ -724,7 +724,8 @@ static void __parse_link(tzdb& __tzdb, std::istream& __input) {
   __tzdb.links.emplace_back(std::move(__name), std::move(__target));
 }
 
-static void __parse_tzdata(
+template <int recordType>
+static void __parse_tzdata_record_type(
     tzdb& __db,
     __rules_storage_type& __rules,
     std::istream& __input) {
@@ -745,24 +746,55 @@ static void __parse_tzdata(
         break;
 
       case 'r':
-        __skip(__input, "ule");
-        __parse_rule(__db, __rules, __input);
-        break;
-
-      case 'z':
-        __skip(__input, "one");
-        __parse_zone(__db, __rules, __input);
+        if constexpr (recordType == 'r') {
+          __skip(__input, "ule");
+          __parse_rule(__db, __rules, __input);
+        } else {
+          __skip_line(__input);
+        }
         break;
 
       case 'l':
-        __skip(__input, "ink");
-        __parse_link(__db, __input);
+        if constexpr (recordType == 'l') {
+          __skip(__input, "ink");
+          __parse_link(__db, __input);
+        } else {
+          __skip_line(__input);
+        }
+        break;
+      
+      case 'z':
+        if constexpr (recordType == 'z') {
+          __skip(__input, "one");
+          __parse_zone(__db, __rules, __input);
+        } else {
+          __skip_line(__input);
+        }
         break;
 
       default:
-        std::__throw_runtime_error("corrupt tzdb: unexpected input");
+        if constexpr (recordType == 'z') {
+          // Only z (Zones) have continuation lines.
+          // When parsing z, any token not matched by the earlier cases is invalid.
+          // (continuations are consumed inside __parse_zone)
+          std::__throw_runtime_error("corrupt tzdb: unexpected input");
+        } else {
+          __skip_line(__input);
+        }
     }
   }
+}
+
+static void __parse_tzdata(
+    tzdb& __db,
+    __rules_storage_type& __rules,
+    std::istream& __input) {
+  // Parse tzdata.zi in order: Rules → Zones → Links.
+  // Zones may reference Rules; Links alias Zones.
+  const std::string buf{std::istreambuf_iterator<char>(__input), {}};
+  { std::istringstream iss(buf); __parse_tzdata_record_type<'r'>(__db, __rules, iss); }
+  { std::istringstream iss(buf); __parse_tzdata_record_type<'z'>(__db, __rules, iss); }
+  { std::istringstream iss(buf); __parse_tzdata_record_type<'l'>(__db, __rules, iss); }
 }
 
 static void __parse_leap_seconds(

--- a/velox/external/tzdb/tzdb.cpp
+++ b/velox/external/tzdb/tzdb.cpp
@@ -753,7 +753,7 @@ static void __parse_tzdata(
         __skip(__input, "one");
         __parse_zone(__db, __rules, __input);
         break;
-      
+
       case 'l':
         __skip(__input, "ink");
         __parse_link(__db, __input);


### PR DESCRIPTION
-1. 修复Print Sink中时间戳向字符串转换的时间精度问题，velox默认精度是纳秒，flink默认是毫秒；
-2.  修复FromElementSource读取时间戳字符串过程中需要考虑时区的问题