### PR TITLE
Support functions current_timestamp

### DIFF
--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -144,6 +144,17 @@ struct UnixTimestampFunction {
 };
 
 template <typename T>
+struct CurrentTimestampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Timestamp>& result) {
+    result = Timestamp::now();
+    return true;
+  }
+};
+
+template <typename T>
 struct UnixTimestampParseFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -94,6 +94,8 @@ void registerDatetimeFunctions(const std::string& prefix) {
       {prefix + "timestamp_millis"});
   registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
       {prefix + "date_trunc"});
+  registerFunction<CurrentTimestampFunction, Timestamp>(
+    {prefix + "current_timestamp"});
 }
 
 } // namespace facebook::velox::functions::sparksql


### PR DESCRIPTION
Support functions current_timestamp, which maps to the flink function proctime