### PR TITLE
[FLINK]Add support for array constant in `BaseVector::createConstant`

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -28,7 +28,6 @@
 #include "velox/vector/VectorEncoding.h"
 #include "velox/vector/VectorPool.h"
 #include "velox/vector/VectorTypeUtils.h"
-#include "velox/vector/VariantToVector.h"
 
 namespace facebook::velox {
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -677,6 +677,221 @@ VectorPtr newConstant<TypeKind::OPAQUE>(
       pool, size, value.isNull(), type, std::shared_ptr<void>(capsule.obj));
 }
 
+namespace {
+
+VectorPtr callMakeVector(
+    TypePtr type,
+    const std::vector<variant>& data,
+    memory::MemoryPool* pool);
+
+template <TypeKind KIND, typename = void>
+struct VariantToVector {
+  static VectorPtr makeVector(
+      TypePtr type,
+      const std::vector<variant>& /*data*/,
+      memory::MemoryPool* /*pool*/) {
+    VELOX_NYI("Type not supported: {}", type->toString());
+  }
+};
+
+template <>
+struct VariantToVector<TypeKind::HUGEINT> {
+  static VectorPtr makeVector(
+      TypePtr type,
+      const std::vector<variant>& /*data*/,
+      memory::MemoryPool* /*pool*/) {
+    VELOX_NYI("Type not supported: {}", type->toString());
+  }
+};
+
+template <TypeKind KIND>
+struct VariantToVector<
+    KIND,
+    std::enable_if_t<
+        TypeTraits<KIND>::isFixedWidth || KIND == TypeKind::VARCHAR ||
+            KIND == TypeKind::VARBINARY || KIND == TypeKind::OPAQUE,
+        void>> {
+  static constexpr bool kIsOpaque = (KIND == TypeKind::OPAQUE);
+  static VectorPtr makeVector(
+      TypePtr type,
+      const std::vector<variant>& data,
+      memory::MemoryPool* pool) {
+    using T = typename TypeTraits<KIND>::NativeType;
+
+    const vector_size_t dataSize = data.size();
+    BufferPtr valuesBuffer = AlignedBuffer::allocate<T>(dataSize, pool);
+    BufferPtr nulls = allocateNulls(dataSize, pool, bits::kNull);
+
+    auto values = std::make_shared<FlatVector<T>>(
+        pool,
+        type,
+        nulls,
+        dataSize,
+        std::move(valuesBuffer),
+        std::vector<BufferPtr>());
+
+    for (size_t i = 0; i < dataSize; i++) {
+      if (!data[i].isNull()) {
+        if constexpr (kIsOpaque) {
+          values->set(i, T(data[i].value<KIND>().obj));
+        } else {
+          values->set(i, T(data[i].value<KIND>()));
+        }
+      }
+    }
+    return values;
+  }
+};
+
+template <>
+struct VariantToVector<TypeKind::ARRAY> {
+  static VectorPtr makeVector(
+      TypePtr type,
+      const std::vector<variant>& data,
+      memory::MemoryPool* pool) {
+    vector_size_t size = data.size();
+    BufferPtr offsets = allocateOffsets(size, pool);
+    BufferPtr sizes = allocateSizes(size, pool);
+    BufferPtr nulls = allocateNulls(size, pool);
+    auto rawOffsets = offsets->asMutable<vector_size_t>();
+    auto rawSizes = sizes->asMutable<vector_size_t>();
+    auto rawNulls = nulls->asMutable<uint64_t>();
+
+    std::vector<variant> elements;
+    vector_size_t index = 0;
+    vector_size_t nullCount = 0;
+    for (size_t i = 0; i < data.size(); ++i) {
+      auto isNull = data[i].isNull();
+      *rawOffsets++ = index;
+      *rawSizes++ = !isNull ? data[i].array().size() : 0;
+      if (isNull) {
+        ++nullCount;
+        bits::setNull(rawNulls, i, true);
+        continue;
+      }
+      for (const auto& arrayElement : data[i].array()) {
+        elements.push_back(arrayElement);
+        ++index;
+      }
+    }
+
+    auto elementsVector = callMakeVector(type->childAt(0), elements, pool);
+
+    return std::make_shared<ArrayVector>(
+        pool,
+        type,
+        nulls,
+        size,
+        offsets,
+        sizes,
+        std::move(elementsVector),
+        nullCount);
+  }
+};
+
+template <>
+struct VariantToVector<TypeKind::MAP> {
+  static VectorPtr makeVector(
+      TypePtr type,
+      const std::vector<variant>& data,
+      memory::MemoryPool* pool) {
+    vector_size_t size = data.size();
+    BufferPtr offsets = allocateOffsets(size, pool);
+    BufferPtr sizes = allocateSizes(size, pool);
+    BufferPtr nulls = allocateNulls(size, pool);
+    auto rawOffsets = offsets->asMutable<vector_size_t>();
+    auto rawSizes = sizes->asMutable<vector_size_t>();
+    auto rawNulls = nulls->asMutable<uint64_t>();
+
+    std::vector<variant> keys;
+    std::vector<variant> values;
+    vector_size_t index = 0;
+    vector_size_t nullCount = 0;
+    for (size_t i = 0; i < data.size(); ++i) {
+      auto isNull = data[i].isNull();
+      *rawOffsets++ = index;
+      *rawSizes++ = !isNull ? data[i].map().size() : 0;
+      if (isNull) {
+        ++nullCount;
+        bits::setNull(rawNulls, i, true);
+        continue;
+      }
+      for (const auto& pair : data[i].map()) {
+        keys.push_back(pair.first);
+        values.push_back(pair.second);
+        ++index;
+      }
+    }
+
+    auto keysVector = callMakeVector(type->childAt(0), keys, pool);
+    auto valuesVector = callMakeVector(type->childAt(1), values, pool);
+
+    return std::make_shared<MapVector>(
+        pool,
+        type,
+        nulls,
+        size,
+        offsets,
+        sizes,
+        std::move(keysVector),
+        std::move(valuesVector),
+        nullCount);
+  }
+};
+
+template <>
+struct VariantToVector<TypeKind::ROW> {
+  static VectorPtr makeVector(
+      TypePtr type,
+      const std::vector<variant>& data,
+      memory::MemoryPool* pool) {
+    vector_size_t size = data.size();
+    BufferPtr nulls = allocateNulls(size, pool);
+    auto rawNulls = nulls->asMutable<uint64_t>();
+
+    auto childCount = type->size();
+    std::vector<std::vector<variant>> children;
+    children.reserve(childCount);
+    for (size_t i = 0; i < childCount; ++i) {
+      std::vector<variant> child;
+      child.reserve(size);
+      children.push_back(child);
+    }
+
+    for (size_t i = 0; i < data.size(); ++i) {
+      if (data[i].isNull()) {
+        bits::setNull(rawNulls, i, true);
+        continue;
+      }
+      const auto& row = data[i].row();
+      VELOX_CHECK_EQ(row.size(), children.size());
+      for (size_t j = 0; j < row.size(); ++j) {
+        children[j].push_back(row[j]);
+      }
+    }
+
+    std::vector<VectorPtr> childVectors;
+    childVectors.reserve(childCount);
+    for (size_t i = 0; i < childCount; ++i) {
+      childVectors.push_back(
+          callMakeVector(type->childAt(i), children[i], pool));
+    }
+
+    return std::make_shared<RowVector>(
+        pool, type, nulls, size, std::move(childVectors));
+  }
+};
+
+VectorPtr callMakeVector(
+    TypePtr type,
+    const std::vector<variant>& data,
+    memory::MemoryPool* pool) {
+  return VELOX_DYNAMIC_TYPE_DISPATCH_METHOD_ALL(
+      VariantToVector, makeVector, type->kind(), type, data, pool);
+}
+
+} // namespace
+
 // static
 VectorPtr BaseVector::createConstant(
     const TypePtr& type,
@@ -684,13 +899,17 @@ VectorPtr BaseVector::createConstant(
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
   VELOX_CHECK_EQ(type->kind(), value.kind());
-  if (type->isArray()) {
-    auto arrayVector = core::variantArrayToVector(type, value.array(), pool);
-    return std::make_shared<ConstantVector<ComplexType>>(pool, arrayVector->size(), 0, arrayVector);
-  } else {
+  if (type->isPrimitiveType()) {
     return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
       newConstant, value.kind(), type, value, size, pool);
   }
+
+  if (value.isNull()) {
+    return BaseVector::createNullConstant(type, size, pool);
+  }
+
+  auto variantVector = callMakeVector(type, {value}, pool);
+  return BaseVector::wrapInConstant(size, 0, std::move(variantVector));
 }
 
 // static

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -28,6 +28,7 @@
 #include "velox/vector/VectorEncoding.h"
 #include "velox/vector/VectorPool.h"
 #include "velox/vector/VectorTypeUtils.h"
+#include "velox/vector/VariantToVector.h"
 
 namespace facebook::velox {
 
@@ -683,8 +684,13 @@ VectorPtr BaseVector::createConstant(
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
   VELOX_CHECK_EQ(type->kind(), value.kind());
-  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+  if (type->isArray()) {
+    auto arrayVector = core::variantArrayToVector(type, value.array(), pool);
+    return std::make_shared<ConstantVector<ComplexType>>(pool, arrayVector->size(), 0, arrayVector);
+  } else {
+    return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
       newConstant, value.kind(), type, value, size, pool);
+  }
 }
 
 // static


### PR DESCRIPTION
修复function in 无法map 到velox 函数的问题，这里主要解决的是 常量array 无法转换到 velox `ConstantVector` 的问题