### PR TITLE
Refactor input/output interface of stateful operators

### DIFF
--- a/velox/experimental/stateful/GroupWindowAggregator.cpp
+++ b/velox/experimental/stateful/GroupWindowAggregator.cpp
@@ -69,12 +69,13 @@ void GroupWindowAggregator::initialize() {
   windowFunction_->open(windowContext_);
 }
 
-void GroupWindowAggregator::addInput(RowVectorPtr input) {
+void GroupWindowAggregator::addInput(StreamElementPtr input) {
   VELOX_CHECK(!input_, "Last input has not been processed");
-  input_ = input;
+  auto record = std::static_pointer_cast<StreamRecord>(input);
+  input_ = record->record();
 }
 
-void GroupWindowAggregator::getOutput() {
+void GroupWindowAggregator::advance() {
   if (!input_) {
     return;
   }
@@ -133,7 +134,8 @@ void GroupWindowAggregator::onEventTime(
   }
   auto output = windowState_->value(timer->key(), timer->ns());
   windowState_->remove(timer->key(), timer->ns());
-  pushOutput(output);
+  pushOutput(
+      std::make_shared<StreamRecord>(getPlanNodeId(), std::move(output)));
 }
 
 void GroupWindowAggregator::close() {
@@ -172,8 +174,9 @@ void GroupWindowAggregator::emitWindowResult(uint32_t key, TimeWindow window) {
     // TODO: use recordCounter_
     // if (!recordCounter_.recordCountIsZero(acc)) {
     if (acc) {
-      // Send INSERT.
-      pushOutput(aggResult);
+      // send INSERT
+      pushOutput(std::make_shared<StreamRecord>(
+          getPlanNodeId(), std::move(aggResult)));
     }
     // if the counter is zero, no need to send accumulate
     // there is no possible skip `if` branch when `produceUpdates` is false
@@ -231,6 +234,7 @@ int64_t GroupWindowAggregator::WindowTriggerContext::getCurrentWatermark() {
 void GroupWindowAggregator::WindowTriggerContext::registerProcessingTimeTimer(
     uint32_t key,
     TimeWindow window,
+
     int64_t time) {
   internalTimerService_->registerProcessingTimeTimer(key, window, time);
 }

--- a/velox/experimental/stateful/GroupWindowAggregator.cpp
+++ b/velox/experimental/stateful/GroupWindowAggregator.cpp
@@ -169,7 +169,7 @@ void GroupWindowAggregator::emitWindowResult(uint32_t key, TimeWindow window) {
   RowVectorPtr acc = windowAggregator_->getAccumulators();
   RowVectorPtr aggResult = windowAggregator_->getValue(window);
   if (produceUpdates_) {
-    // TODO: suppport it.
+    // TODO: support it.
   } else {
     // TODO: use recordCounter_
     // if (!recordCounter_.recordCountIsZero(acc)) {

--- a/velox/experimental/stateful/GroupWindowAggregator.h
+++ b/velox/experimental/stateful/GroupWindowAggregator.h
@@ -49,10 +49,8 @@ class GroupWindowAggregator : public StatefulOperator,
       int shiftTimeZone = 0);
 
   void initialize() override;
-
-  void addInput(RowVectorPtr input) override;
-
-  void getOutput() override;
+  void addInput(StreamElementPtr input) override;
+  void advance() override;
 
   void close() override;
 

--- a/velox/experimental/stateful/KeySelector.cpp
+++ b/velox/experimental/stateful/KeySelector.cpp
@@ -32,7 +32,7 @@ std::map<uint32_t, RowVectorPtr> KeySelector::partition(
   }
   prepareForInput(input);
 
-  // TODO: The partition function doesn't use max parallism.
+  // TODO: The partition function doesn't use max parallelism.
   std::vector<uint32_t> partitions(input->size());
   auto part = partitionFunction_->partition(*input, partitions);
   if (part) {

--- a/velox/experimental/stateful/LocalWindowAggregator.cpp
+++ b/velox/experimental/stateful/LocalWindowAggregator.cpp
@@ -36,12 +36,13 @@ LocalWindowAggregator::LocalWindowAggregator(
   windowBuffer_ = std::make_shared<RecordsWindowBuffer>();
 }
 
-void LocalWindowAggregator::addInput(RowVectorPtr input) {
+void LocalWindowAggregator::addInput(StreamElementPtr input) {
   VELOX_CHECK(!input_, "Last input has not been processed");
-  input_ = input;
+  auto record = std::static_pointer_cast<StreamRecord>(input);
+  input_ = record->record();
 }
 
-void LocalWindowAggregator::getOutput() {
+void LocalWindowAggregator::advance() {
   if (!input_) {
     return;
   }
@@ -74,8 +75,9 @@ void LocalWindowAggregator::processWatermarkInternal(int64_t timestamp) {
         op()->addInput(TimeWindowUtil::mergeVectors(datas, op()->pool()));
         RowVectorPtr output = op()->getOutput();
         if (output) {
-          pushOutput(
-              addWindowEndToVector(std::move(output), windowKey.window()));
+          pushOutput(std::make_shared<StreamRecord>(
+              getPlanNodeId(),
+              addWindowEndToVector(std::move(output), windowKey.window())));
         }
       }
       nextTriggerWatermark_ = TimeWindowUtil::getNextTriggerWatermark(

--- a/velox/experimental/stateful/LocalWindowAggregator.h
+++ b/velox/experimental/stateful/LocalWindowAggregator.h
@@ -18,6 +18,7 @@
 
 #include "velox/experimental/stateful/KeySelector.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
+#include "velox/experimental/stateful/StreamElement.h"
 #include "velox/experimental/stateful/window/WindowBuffer.h"
 
 namespace facebook::velox::stateful {
@@ -35,9 +36,9 @@ class LocalWindowAggregator : public StatefulOperator {
       const bool useDayLightSaving,
       RowTypePtr outputType);
 
-  void addInput(RowVectorPtr input) override;
+  void addInput(StreamElementPtr input) override;
 
-  void getOutput() override;
+  void advance() override;
 
   void close() override;
 

--- a/velox/experimental/stateful/RuntimeContext.h
+++ b/velox/experimental/stateful/RuntimeContext.h
@@ -28,7 +28,7 @@ class RuntimeContext {
       : operatorId_(operatorId),
         keyedStateBackend_(std::move(keyedStateBackend)){};
 
-  // The type of state has to be specified as c++ not support template well.
+  // The type of state has to be specified as C++ does not support templates well.
   std::shared_ptr<MapState<uint32_t, int32_t, RowVectorPtr, int32_t>>
   getMapState(StateDescriptor& stateDescriptor) {
     return keyedStateBackend_->getOrCreateMapState(stateDescriptor);

--- a/velox/experimental/stateful/StatefulOperator.cpp
+++ b/velox/experimental/stateful/StatefulOperator.cpp
@@ -114,9 +114,7 @@ void StatefulOperator::initializeStateBackend(StateBackend* stateBackend) {
   if (!stateHandler_) {
     stateHandler_ = std::make_shared<StreamOperatorStateHandler>(
         op()->operatorId(),
-        stateBackend->createKeyedStateBackend(KeyedStateBackendParameters(
-            op()->operatorCtx()->driverCtx()->task->taskId(),
-            op()->operatorId())));
+        stateBackend->createKeyedStateBackend());
   }
   auto snapshotable = dynamic_cast<Snapshotable*>(op().get());
   if (snapshotable) {

--- a/velox/experimental/stateful/StatefulOperator.cpp
+++ b/velox/experimental/stateful/StatefulOperator.cpp
@@ -33,9 +33,10 @@ bool StatefulOperator::isFinished() {
   return operator_->isFinished();
 }
 
-void StatefulOperator::addInput(RowVectorPtr input) {
-  operator_->traceInput(input);
-  operator_->addInput(std::move(input));
+void StatefulOperator::addInput(StreamElementPtr input) {
+  auto record = std::static_pointer_cast<StreamRecord>(input);
+  operator_->traceInput(record->record());
+  operator_->addInput(record->record());
 }
 
 bool StatefulOperator::sourceEmpty() {
@@ -51,32 +52,31 @@ void StatefulOperator::close() {
   targets_.clear();
 }
 
-void StatefulOperator::getOutput() {
+void StatefulOperator::advance() {
   sourceEmpty_ = true;
   auto intermediateResult = operator_->getOutput();
   if (!intermediateResult) {
     return;
   }
   sourceEmpty_ = false;
-  pushOutput(std::move(intermediateResult));
+  pushOutput(std::make_shared<StreamRecord>(
+      getPlanNodeId(), std::move(intermediateResult)));
 }
 
-void StatefulOperator::pushOutput(RowVectorPtr output) {
+void StatefulOperator::pushOutput(StreamElementPtr output) {
   if (targets_.empty()) {
-    auto outNodeId = operator_->planNodeId();
     auto task = std::static_pointer_cast<StatefulTask>(
         operator_->operatorCtx()->driverCtx()->task);
-    task->addOutput(
-        std::make_shared<StreamRecord>(outNodeId, std::move(output)));
+    task->addOutput(std::move(output));
     return;
   }
-  for (int i = 0; i < targets_.size() - 1; i++) {
-    auto copy = output;
-    targets_[i]->addInput(std::move(copy));
-    targets_[i]->getOutput();
+
+  for (size_t i = 0; i < targets_.size() - 1; i++) {
+    targets_[i]->addInput(output);
+    targets_[i]->advance();
   }
-  targets_[targets_.size() - 1]->addInput(std::move(output));
-  targets_[targets_.size() - 1]->getOutput();
+  targets_[targets_.size() - 1]->addInput(output);
+  targets_[targets_.size() - 1]->advance();
 }
 
 void StatefulOperator::emitWatermark(int64_t timestamp) {
@@ -87,10 +87,9 @@ void StatefulOperator::emitWatermark(int64_t timestamp) {
   }
 
   if (targets_.empty()) {
-    auto outNodeId = operator_->planNodeId();
     auto task = std::static_pointer_cast<StatefulTask>(
         operator_->operatorCtx()->driverCtx()->task);
-    task->addOutput(std::make_shared<Watermark>(outNodeId, timestamp));
+    task->addOutput(std::make_shared<Watermark>(getPlanNodeId(), timestamp));
     return;
   }
   for (auto& target : targets_) {
@@ -114,7 +113,10 @@ void StatefulOperator::processWatermark(int64_t timestamp) {
 void StatefulOperator::initializeStateBackend(StateBackend* stateBackend) {
   if (!stateHandler_) {
     stateHandler_ = std::make_shared<StreamOperatorStateHandler>(
-        op()->operatorId(), stateBackend->createKeyedStateBackend());
+        op()->operatorId(),
+        stateBackend->createKeyedStateBackend(KeyedStateBackendParameters(
+            op()->operatorCtx()->driverCtx()->task->taskId(),
+            op()->operatorId())));
   }
   auto snapshotable = dynamic_cast<Snapshotable*>(op().get());
   if (snapshotable) {
@@ -148,6 +150,7 @@ std::vector<std::string> StatefulOperator::notifyCheckpointComplete(
   if (!stateHandler_) {
     return {};
   }
+
   stateHandler_->notifyCheckpointComplete(checkpointId);
   auto checkpointListener = dynamic_cast<CheckpointListener*>(op().get());
   if (checkpointListener) {

--- a/velox/experimental/stateful/StatefulOperator.h
+++ b/velox/experimental/stateful/StatefulOperator.h
@@ -19,6 +19,7 @@
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/exec/Operator.h"
 #include "velox/experimental/stateful/CombinedWatermarkStatus.h"
+#include "velox/experimental/stateful/StreamElement.h"
 #include "velox/experimental/stateful/state/StateBackend.h"
 #include "velox/experimental/stateful/state/StreamOperatorStateHandler.h"
 
@@ -41,9 +42,9 @@ class StatefulOperator {
 
   virtual bool isFinished();
 
-  virtual void addInput(RowVectorPtr input);
+  virtual void addInput(StreamElementPtr input);
 
-  virtual void getOutput();
+  virtual void advance();
 
   bool sourceEmpty();
 
@@ -84,6 +85,10 @@ class StatefulOperator {
     return operator_->operatorType();
   }
 
+  std::string getPlanNodeId() const {
+    return operator_->planNodeId();
+  }
+
   std::unique_ptr<exec::Operator>& op() {
     return operator_;
   }
@@ -93,7 +98,7 @@ class StatefulOperator {
   }
 
  protected:
-  void pushOutput(RowVectorPtr output);
+  void pushOutput(StreamElementPtr output);
   void emitWatermark(int64_t timestamp);
 
   virtual int numInputs() const {

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -125,7 +125,7 @@ StreamElementPtr StatefulTask::next(int32_t& retCode) {
       exec::TaskState::kRunning,
       "Task has already finished processing.");
 
-  operatorChain_->getOutput();
+  operatorChain_->advance();
   if (pendings_.empty()) {
     if (operatorChain_->isFinished()) {
       finish();

--- a/velox/experimental/stateful/StreamJoin.cpp
+++ b/velox/experimental/stateful/StreamJoin.cpp
@@ -49,7 +49,7 @@ bool StreamJoin::isFinished() {
   return leftInput_->isFinished() && rightInput_->isFinished();
 }
 
-void StreamJoin::addInput(RowVectorPtr input) {
+void StreamJoin::addInput(StreamElementPtr input) {
   VELOX_NYI();
 }
 
@@ -61,7 +61,7 @@ void StreamJoin::close() {
   rightRecordStateView_->close();
 }
 
-void StreamJoin::getOutput() {
+void StreamJoin::advance() {
   // TODO: use nested loop join logic to produce output now.
   // But it's not equal to Flink's streaming join.
   auto leftResult = leftInput_->getOutput();
@@ -71,7 +71,8 @@ void StreamJoin::getOutput() {
       leftRecordStateView_->addRecord(key, data);
       auto result = join(key, data, rightRecordStateView_, true);
       if (result) {
-        pushOutput(result);
+        pushOutput(
+            std::make_shared<StreamRecord>(getPlanNodeId(), std::move(result)));
       }
     }
   }
@@ -83,7 +84,8 @@ void StreamJoin::getOutput() {
       rightRecordStateView_->addRecord(key, data);
       auto result = join(key, data, leftRecordStateView_, false);
       if (result) {
-        pushOutput(result);
+        pushOutput(
+            std::make_shared<StreamRecord>(getPlanNodeId(), std::move(result)));
       }
     }
   }

--- a/velox/experimental/stateful/StreamJoin.h
+++ b/velox/experimental/stateful/StreamJoin.h
@@ -19,6 +19,7 @@
 #include "velox/experimental/stateful/KeySelector.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
 #include "velox/experimental/stateful/StatefulPlanNode.h"
+#include "velox/experimental/stateful/StreamElement.h"
 #include "velox/experimental/stateful/join/JoinRecordStateView.h"
 
 namespace facebook::velox::stateful {
@@ -37,9 +38,9 @@ class StreamJoin : public StatefulOperator {
 
   bool isFinished() override;
 
-  void addInput(RowVectorPtr input) override;
+  void addInput(StreamElementPtr input) override;
 
-  void getOutput() override;
+  void advance() override;
 
   void close() override;
 

--- a/velox/experimental/stateful/StreamKeyedOperator.cpp
+++ b/velox/experimental/stateful/StreamKeyedOperator.cpp
@@ -36,21 +36,23 @@ bool StreamKeyedOperator::isFinished() {
   return false;
 }
 
-void StreamKeyedOperator::addInput(RowVectorPtr input) {
+void StreamKeyedOperator::addInput(StreamElementPtr input) {
   VELOX_CHECK_NULL(input_);
-  input_ = std::move(input);
+  auto record = std::static_pointer_cast<StreamRecord>(input);
+  input_ = record->record();
 }
 
 void StreamKeyedOperator::close() {
   StatefulOperator::close();
 }
 
-void StreamKeyedOperator::getOutput() {
+void StreamKeyedOperator::advance() {
   auto keyToData = keySelector_->partition(input_);
   for (auto& [key, data] : keyToData) {
     auto result = processor_->processElements(key, data);
     if (result) {
-      pushOutput(result);
+      pushOutput(
+          std::make_shared<StreamRecord>(getPlanNodeId(), std::move(result)));
     }
   }
   input_.reset();

--- a/velox/experimental/stateful/StreamKeyedOperator.h
+++ b/velox/experimental/stateful/StreamKeyedOperator.h
@@ -18,6 +18,7 @@
 #include "velox/exec/Operator.h"
 #include "velox/experimental/stateful/KeySelector.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
+#include "velox/experimental/stateful/StreamElement.h"
 #include "velox/experimental/stateful/functions/KeyedProcessFunction.h"
 
 namespace facebook::velox::stateful {
@@ -33,9 +34,9 @@ class StreamKeyedOperator : public StatefulOperator {
 
   bool isFinished() override;
 
-  void addInput(RowVectorPtr input) override;
+  void addInput(StreamElementPtr input) override;
 
-  void getOutput() override;
+  void advance() override;
 
   void close() override;
 

--- a/velox/experimental/stateful/StreamPartition.cpp
+++ b/velox/experimental/stateful/StreamPartition.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include "velox/experimental/stateful/StatefulTask.h"
 
+
 namespace facebook::velox::stateful {
 
 StreamPartition::StreamPartition(
@@ -36,16 +37,17 @@ bool StreamPartition::isFinished() {
   return false;
 }
 
-void StreamPartition::addInput(RowVectorPtr input) {
+void StreamPartition::addInput(StreamElementPtr input) {
   VELOX_CHECK_NULL(input_);
-  input_ = std::move(input);
+  auto record = std::static_pointer_cast<StreamRecord>(input);
+  input_ = record->record();
 }
 
-void StreamPartition::getOutput() {
+void StreamPartition::advance() {
   prepareForInput(input_);
 
   if (numPartitions_ == 1) {
-    pushToTask(std::make_shared<StreamRecord>(op()->planNodeId(), 0, input_));
+    pushToTask(std::make_shared<StreamRecord>(getPlanNodeId(), 0, input_));
     input_.reset();
     return;
   }
@@ -75,7 +77,7 @@ void StreamPartition::getOutput() {
     }
     auto partitionData = wrapChildren(input_, partitionSize, indexBuffers_[i]);
     pushToTask(
-        std::make_shared<StreamRecord>(op()->planNodeId(), i, partitionData));
+        std::make_shared<StreamRecord>(getPlanNodeId(), i, partitionData));
   }
   input_.reset();
 }

--- a/velox/experimental/stateful/StreamPartition.cpp
+++ b/velox/experimental/stateful/StreamPartition.cpp
@@ -17,7 +17,6 @@
 #include <cstdint>
 #include "velox/experimental/stateful/StatefulTask.h"
 
-
 namespace facebook::velox::stateful {
 
 StreamPartition::StreamPartition(

--- a/velox/experimental/stateful/StreamPartition.cpp
+++ b/velox/experimental/stateful/StreamPartition.cpp
@@ -51,7 +51,7 @@ void StreamPartition::advance() {
     return;
   }
 
-  // TODO: The partition function doesn't use max parallism.
+  // TODO: The partition function doesn't use max parallelism.
   partitionFunction_->partition(*input_, partitions_);
   const auto numInput = input_->size();
   std::vector<vector_size_t> maxIndex(numPartitions_, 0);

--- a/velox/experimental/stateful/StreamPartition.h
+++ b/velox/experimental/stateful/StreamPartition.h
@@ -30,9 +30,9 @@ class StreamPartition : public StatefulOperator {
 
   bool isFinished() override;
 
-  void addInput(RowVectorPtr input) override;
+  void addInput(StreamElementPtr input) override;
 
-  void getOutput() override;
+  void advance() override;
 
   std::string name() const override {
     return "StreamPartition";

--- a/velox/experimental/stateful/WatermarkAssigner.cpp
+++ b/velox/experimental/stateful/WatermarkAssigner.cpp
@@ -32,12 +32,14 @@ WatermarkAssigner::WatermarkAssigner(
       rowtimeFieldIndex_(rowtimeFieldIndex),
       watermarkInterval_(watermarkInterval) {}
 
-void WatermarkAssigner::addInput(RowVectorPtr input) {
-  input_ = input;
-  op()->addInput(std::move(input));
+void WatermarkAssigner::addInput(StreamElementPtr input) {
+  auto record = std::static_pointer_cast<StreamRecord>(input);
+  input_ = record->record();
+  op()->addInput(input_);
 }
 
-void WatermarkAssigner::getOutput() {
+
+void WatermarkAssigner::advance() {
   if (!input_) {
     return;
   }
@@ -81,7 +83,8 @@ void WatermarkAssigner::getOutput() {
         auto output = std::dynamic_pointer_cast<RowVector>(
             input_->slice(lastIndex, i - lastIndex + 1));
         lastIndex = i + 1;
-        pushOutput(std::move(output));
+        pushOutput(
+            std::make_shared<StreamRecord>(getPlanNodeId(), std::move(output)));
         advanceWatermark();
         // Update threshold after watermark advance
         nextWatermarkThreshold = lastWatermark + watermarkInterval_;
@@ -91,11 +94,13 @@ void WatermarkAssigner::getOutput() {
 
   // Handle remaining data
   if (lastIndex == 0) {
-    pushOutput(std::move(input_));
+    pushOutput(
+        std::make_shared<StreamRecord>(getPlanNodeId(), std::move(input_)));
   } else if (lastIndex < timestampSize) {
     auto output = std::dynamic_pointer_cast<RowVector>(
         input_->slice(lastIndex, timestampSize - lastIndex));
-    pushOutput(std::move(output));
+    pushOutput(
+        std::make_shared<StreamRecord>(getPlanNodeId(), std::move(output)));
   }
   input_.reset();
 }

--- a/velox/experimental/stateful/WatermarkAssigner.cpp
+++ b/velox/experimental/stateful/WatermarkAssigner.cpp
@@ -38,7 +38,6 @@ void WatermarkAssigner::addInput(StreamElementPtr input) {
   op()->addInput(input_);
 }
 
-
 void WatermarkAssigner::advance() {
   if (!input_) {
     return;

--- a/velox/experimental/stateful/WatermarkAssigner.h
+++ b/velox/experimental/stateful/WatermarkAssigner.h
@@ -24,7 +24,7 @@ namespace facebook::velox::stateful {
 
 /// It is related to
 /// org.apache.flink.table.runtime.operators.wmassigners.WatermarkAssignerOperator
-/// in Flink. It extracts timestamp from each row and generate periodic
+/// in Flink. It extracts timestamp from each row and generates periodic
 /// watermark.
 class WatermarkAssigner : public StatefulOperator {
  public:

--- a/velox/experimental/stateful/WatermarkAssigner.h
+++ b/velox/experimental/stateful/WatermarkAssigner.h
@@ -17,6 +17,8 @@
 #include <cstdint>
 
 #include "velox/experimental/stateful/StatefulOperator.h"
+#include "velox/experimental/stateful/StatefulPlanNode.h"
+#include "velox/experimental/stateful/StreamElement.h"
 
 namespace facebook::velox::stateful {
 
@@ -33,9 +35,9 @@ class WatermarkAssigner : public StatefulOperator {
       const int rowtimeFieldIndex,
       const int64_t watermarkInterval);
 
-  void addInput(RowVectorPtr input) override;
+  void addInput(StreamElementPtr input) override;
 
-  void getOutput() override;
+  void advance() override;
 
   std::string name() const override {
     return "WatermarkAssigner";

--- a/velox/experimental/stateful/WindowAggregator.cpp
+++ b/velox/experimental/stateful/WindowAggregator.cpp
@@ -47,12 +47,13 @@ void WindowAggregator::initialize() {
   windowTimerService_ = stateHandler()->createTimerService(this);
 }
 
-void WindowAggregator::addInput(RowVectorPtr input) {
+void WindowAggregator::addInput(StreamElementPtr input) {
   VELOX_CHECK(!input_, "Last input has not been processed");
-  input_ = input;
+  auto record = std::static_pointer_cast<StreamRecord>(input);
+  input_ = record->record();
 }
 
-void WindowAggregator::getOutput() {
+void WindowAggregator::advance() {
   if (!input_) {
     return;
   }
@@ -75,6 +76,7 @@ void WindowAggregator::getOutput() {
         // the assigned slice has been triggered, which means current element is
         // late, but maybe not need to drop
         int64_t lastWindowEnd = sliceAssigner_->getLastWindowEnd(sliceEnd);
+
         if (TimeWindowUtil::isWindowFired(
                 lastWindowEnd, currentProgress_, shiftTimeZone_)) {
           // the last window has been triggered, so the element can be dropped
@@ -154,7 +156,8 @@ void WindowAggregator::onEventTime(
     std::shared_ptr<TimerHeapInternalTimer<uint32_t, int64_t>> timer) {
   auto output = windowState_->value(timer->key(), timer->ns());
   windowState_->remove(timer->key(), timer->ns());
-  pushOutput(output);
+  pushOutput(
+      std::make_shared<StreamRecord>(getPlanNodeId(), std::move(output)));
 }
 
 int64_t WindowAggregator::sliceStateMergeTarget(int64_t sliceToMerge) {

--- a/velox/experimental/stateful/WindowAggregator.cpp
+++ b/velox/experimental/stateful/WindowAggregator.cpp
@@ -119,7 +119,7 @@ void WindowAggregator::processWatermarkInternal(int64_t timestamp) {
         if (datas.empty()) {
           continue;
         }
-        // TODO: agg should output no matter how many rows in datas.
+        // TODO: agg should output no matter how many rows in data.
         localAggerator_->addInput(
             TimeWindowUtil::mergeVectors(datas, op()->pool()));
         RowVectorPtr localAcc = localAggerator_->getOutput();

--- a/velox/experimental/stateful/WindowAggregator.h
+++ b/velox/experimental/stateful/WindowAggregator.h
@@ -19,6 +19,7 @@
 #include "velox/experimental/stateful/InternalTimerService.h"
 #include "velox/experimental/stateful/KeySelector.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
+#include "velox/experimental/stateful/StreamElement.h"
 #include "velox/experimental/stateful/TimerHeapInternalTimer.h"
 #include "velox/experimental/stateful/Triggerable.h"
 #include "velox/experimental/stateful/window/SliceAssigner.h"
@@ -42,9 +43,9 @@ class WindowAggregator : public StatefulOperator,
 
   void initialize() override;
 
-  void addInput(RowVectorPtr input) override;
+  void addInput(StreamElementPtr input) override;
 
-  void getOutput() override;
+  void advance() override;
 
   void close() override;
 

--- a/velox/experimental/stateful/WindowAggregator.h
+++ b/velox/experimental/stateful/WindowAggregator.h
@@ -28,7 +28,7 @@
 namespace facebook::velox::stateful {
 
 /// This class is related to XXXWindowAggProcessor in Flink.
-/// It's work includes both WindowAggOperator and XXXWindowAggOperator.
+/// Its work includes both WindowAggOperator and XXXWindowAggOperator.
 class WindowAggregator : public StatefulOperator,
                          public Triggerable<uint32_t, int64_t> {
  public:

--- a/velox/experimental/stateful/WindowJoin.cpp
+++ b/velox/experimental/stateful/WindowJoin.cpp
@@ -54,7 +54,7 @@ bool WindowJoin::isFinished() {
   return leftInput_->isFinished() && rightInput_->isFinished();
 }
 
-void WindowJoin::addInput(RowVectorPtr input) {
+void WindowJoin::addInput(StreamElementPtr input) {
   VELOX_NYI();
 }
 
@@ -66,7 +66,7 @@ void WindowJoin::close() {
   rightWindowState_->clear();
 }
 
-void WindowJoin::getOutput() {
+void WindowJoin::advance() {
   // TODO: use nested loop join logic to produce output now.
   // But it's not equal to Flink's streaming join.
   processData(
@@ -136,7 +136,8 @@ void WindowJoin::join(uint32_t key, int64_t window) {
     probe_->setBuildData(buildVector);
 
     auto result = probe_->getOutput();
-    pushOutput(result);
+    pushOutput(
+        std::make_shared<StreamRecord>(getPlanNodeId(), std::move(result)));
   }
   // TODO: clear state
   leftWindowState_->remove(key, window);

--- a/velox/experimental/stateful/WindowJoin.h
+++ b/velox/experimental/stateful/WindowJoin.h
@@ -21,10 +21,7 @@
 #include "velox/experimental/stateful/KeySelector.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
 #include "velox/experimental/stateful/StatefulPlanNode.h"
-<<<<<<< HEAD
-=======
 #include "velox/experimental/stateful/StreamElement.h"
-    >>>>>>> 72bb1ba5f (refactor(stateful): route addInput through StreamElementPtr)
 #include "velox/experimental/stateful/TimerHeapInternalTimer.h"
 #include "velox/experimental/stateful/Triggerable.h"
 #include "velox/experimental/stateful/join/JoinRecordStateView.h"
@@ -79,11 +76,7 @@
 
     RowVectorPtr filterWindowFiredRows(RowVectorPtr& input);
 
-<<<<<<< HEAD
     std::map<int64_t, RowVectorPtr> partitionWindowData(
-=======
-    std::map<long, RowVectorPtr> partitionWindowData(
->>>>>>> 72bb1ba5f (refactor(stateful): route addInput through StreamElementPtr)
         RowVectorPtr& input,
         int windowEndIndex);
 

--- a/velox/experimental/stateful/WindowJoin.h
+++ b/velox/experimental/stateful/WindowJoin.h
@@ -21,6 +21,10 @@
 #include "velox/experimental/stateful/KeySelector.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
 #include "velox/experimental/stateful/StatefulPlanNode.h"
+<<<<<<< HEAD
+=======
+#include "velox/experimental/stateful/StreamElement.h"
+>>>>>>> 72bb1ba5f (refactor(stateful): route addInput through StreamElementPtr)
 #include "velox/experimental/stateful/TimerHeapInternalTimer.h"
 #include "velox/experimental/stateful/Triggerable.h"
 #include "velox/experimental/stateful/join/JoinRecordStateView.h"
@@ -44,9 +48,9 @@ class WindowJoin : public StatefulOperator,
 
   bool isFinished() override;
 
-  void addInput(RowVectorPtr input) override;
+  void addInput(StreamElementPtr input) override;
 
-  void getOutput() override;
+  void advance() override;
 
   void close() override;
 
@@ -75,7 +79,11 @@ class WindowJoin : public StatefulOperator,
 
   RowVectorPtr filterWindowFiredRows(RowVectorPtr& input);
 
+<<<<<<< HEAD
   std::map<int64_t, RowVectorPtr> partitionWindowData(
+=======
+  std::map<long, RowVectorPtr> partitionWindowData(
+>>>>>>> 72bb1ba5f (refactor(stateful): route addInput through StreamElementPtr)
       RowVectorPtr& input,
       int windowEndIndex);
 

--- a/velox/experimental/stateful/WindowJoin.h
+++ b/velox/experimental/stateful/WindowJoin.h
@@ -24,79 +24,81 @@
 <<<<<<< HEAD
 =======
 #include "velox/experimental/stateful/StreamElement.h"
->>>>>>> 72bb1ba5f (refactor(stateful): route addInput through StreamElementPtr)
+    >>>>>>> 72bb1ba5f (refactor(stateful): route addInput through StreamElementPtr)
 #include "velox/experimental/stateful/TimerHeapInternalTimer.h"
 #include "velox/experimental/stateful/Triggerable.h"
 #include "velox/experimental/stateful/join/JoinRecordStateView.h"
 
-namespace facebook::velox::stateful {
+    namespace facebook::velox::stateful {
 
-class WindowJoin : public StatefulOperator,
-                   public Triggerable<uint32_t, int64_t> {
- public:
-  WindowJoin(
-      std::unique_ptr<exec::Operator> leftInput,
-      std::unique_ptr<exec::Operator> rightInput,
-      std::unique_ptr<KeySelector> leftKeySelector,
-      std::unique_ptr<KeySelector> rightKeySelector,
-      std::unique_ptr<exec::Operator> probe,
-      std::vector<std::unique_ptr<StatefulOperator>> targets,
-      int leftWindowEndIndex,
-      int rightWindowEndIndex);
+  class WindowJoin : public StatefulOperator,
+                     public Triggerable<uint32_t, int64_t> {
+   public:
+    WindowJoin(
+        std::unique_ptr<exec::Operator> leftInput,
+        std::unique_ptr<exec::Operator> rightInput,
+        std::unique_ptr<KeySelector> leftKeySelector,
+        std::unique_ptr<KeySelector> rightKeySelector,
+        std::unique_ptr<exec::Operator> probe,
+        std::vector<std::unique_ptr<StatefulOperator>> targets,
+        int leftWindowEndIndex,
+        int rightWindowEndIndex);
 
-  void initialize() override;
+    void initialize() override;
 
-  bool isFinished() override;
+    bool isFinished() override;
 
-  void addInput(StreamElementPtr input) override;
+    void addInput(StreamElementPtr input) override;
 
-  void advance() override;
+    void advance() override;
 
-  void close() override;
+    void close() override;
 
-  std::string name() const override {
-    return "WindowJoin";
-  }
+    std::string name() const override {
+      return "WindowJoin";
+    }
 
-  void onEventTime(std::shared_ptr<TimerHeapInternalTimer<uint32_t, int64_t>>
-                       timer) override;
+    void onEventTime(std::shared_ptr<TimerHeapInternalTimer<uint32_t, int64_t>>
+                         timer) override;
 
- protected:
-  int numInputs() const override {
-    return 2;
-  }
+   protected:
+    int numInputs() const override {
+      return 2;
+    }
 
- private:
-  void join(uint32_t key, int64_t windowEnd);
+   private:
+    void join(uint32_t key, int64_t windowEnd);
 
-  void processWatermarkInternal(int64_t timestamp);
+    void processWatermarkInternal(int64_t timestamp);
 
-  void processData(
-      exec::Operator* input,
-      KeySelector* keySelector,
-      int windowEndIndex,
-      ListState<uint32_t, int64_t, RowVectorPtr>* state);
+    void processData(
+        exec::Operator* input,
+        KeySelector* keySelector,
+        int windowEndIndex,
+        ListState<uint32_t, int64_t, RowVectorPtr>* state);
 
-  RowVectorPtr filterWindowFiredRows(RowVectorPtr& input);
+    RowVectorPtr filterWindowFiredRows(RowVectorPtr& input);
 
 <<<<<<< HEAD
-  std::map<int64_t, RowVectorPtr> partitionWindowData(
+    std::map<int64_t, RowVectorPtr> partitionWindowData(
 =======
-  std::map<long, RowVectorPtr> partitionWindowData(
+    std::map<long, RowVectorPtr> partitionWindowData(
 >>>>>>> 72bb1ba5f (refactor(stateful): route addInput through StreamElementPtr)
-      RowVectorPtr& input,
-      int windowEndIndex);
+        RowVectorPtr& input,
+        int windowEndIndex);
 
-  const std::unique_ptr<exec::Operator> leftInput_;
-  const std::unique_ptr<exec::Operator> rightInput_;
-  const std::unique_ptr<KeySelector> leftKeySelector_;
-  const std::unique_ptr<KeySelector> rightKeySelector_;
-  exec::NestedLoopJoinProbe* probe_;
-  std::shared_ptr<ListState<uint32_t, int64_t, RowVectorPtr>> leftWindowState_;
-  std::shared_ptr<ListState<uint32_t, int64_t, RowVectorPtr>> rightWindowState_;
-  const int leftWindowEndIndex_;
-  const int rightWindowEndIndex_;
-  std::shared_ptr<InternalTimerService<uint32_t, int64_t>> timerService_;
-};
+    const std::unique_ptr<exec::Operator> leftInput_;
+    const std::unique_ptr<exec::Operator> rightInput_;
+    const std::unique_ptr<KeySelector> leftKeySelector_;
+    const std::unique_ptr<KeySelector> rightKeySelector_;
+    exec::NestedLoopJoinProbe* probe_;
+    std::shared_ptr<ListState<uint32_t, int64_t, RowVectorPtr>>
+        leftWindowState_;
+    std::shared_ptr<ListState<uint32_t, int64_t, RowVectorPtr>>
+        rightWindowState_;
+    const int leftWindowEndIndex_;
+    const int rightWindowEndIndex_;
+    std::shared_ptr<InternalTimerService<uint32_t, int64_t>> timerService_;
+  };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/state/CheckpointOptions.h
+++ b/velox/experimental/stateful/state/CheckpointOptions.h
@@ -27,7 +27,7 @@ class CheckpointOptions {
   }
 
  private:
-  int64_t chekcpointId = 0;
+  int64_t checkpointId = 0;
   int64_t timestamp = 0;
   bool isSavepoint = false;
 };

--- a/velox/experimental/stateful/state/RocksDBStateBackend.cpp
+++ b/velox/experimental/stateful/state/RocksDBStateBackend.cpp
@@ -37,7 +37,7 @@ RocksDBStateBackend::createKeyedStateBackend() {
               parameters_);
   VELOX_CHECK(
       rocksdbStateParams != nullptr,
-      "The provided parameters is not for rocksdb state backend.");
+      "The provided parameters are not for rocksdb state backend.");
   return std::make_shared<RocksDBKeyedStateBackend>(
       rocksdbStateParams->getDB(),
       rocksdbStateParams->getReadOptions(),

--- a/velox/experimental/stateful/state/RocksDBStateBackend.h
+++ b/velox/experimental/stateful/state/RocksDBStateBackend.h
@@ -93,7 +93,7 @@ class RocksDBKeyedStateBackendParameters : public KeyedStateBackendParameters {
   /// or not.
   std::set<std::string> states_;
   /// The map between state and operators, it's used to justify the relationship
-  /// between the state and the operator. In Flink, the state is binded to
+  /// between the state and the operator. In Flink, the state is bound to
   /// operator one-to-one.
   std::unordered_map<std::string, std::string> stateOperators_;
   std::unordered_map<std::string, int64_t> columnFamilyHandles_;

--- a/velox/experimental/stateful/state/StreamOperatorStateHandler.h
+++ b/velox/experimental/stateful/state/StreamOperatorStateHandler.h
@@ -49,7 +49,7 @@ class StreamOperatorStateHandler {
     keyedStateBackend_->notifyCheckpointAborted(checkpointId);
   }
 
-  // The type of state has to be specified as c++ not support template well.
+  // The type of state has to be specified as C++ does not support templates well.
   std::shared_ptr<MapState<uint32_t, int, RowVectorPtr, int>> getMapState(
       StateDescriptor& stateDescriptor) {
     return keyedStateBackend_->getOrCreateMapState(stateDescriptor);

--- a/velox/experimental/stateful/window/WindowPartitionFunction.cpp
+++ b/velox/experimental/stateful/window/WindowPartitionFunction.cpp
@@ -53,7 +53,7 @@ std::optional<uint32_t> WindowPartitionFunction::partition(
   }
   const auto size = input.size();
   partitions.resize(size);
-  // TODO: suuport more window types. support time zone.
+  // TODO: support more window types. Support time zone.
   for (auto i = 0; i < size; ++i) {
     auto child = input.childAt(rowtimeIndex_);
     auto ts = child->as<SimpleVector<Timestamp>>()->valueAt(i);


### PR DESCRIPTION

Currently, computational data between stateful operators is transmitted using row vectors. In stream computing, the content of computational data can be richer than what row vectors provide. Therefore, it is being refactored to use stream elements instead of row vectors.

The main changes involve refactoring the `addInput` and `pushOutput` methods.
