### PR TITLE
[FLINK] Support timer service

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2195,6 +2195,18 @@ class PartitionFunction {
   virtual std::optional<uint32_t> partition(
       const RowVector& input,
       std::vector<uint32_t>& partitions) = 0;
+
+  /// @param input RowVector to split into partitions.
+  /// @param [out] partitions Computed partition numbers for each row in
+  /// 'input'.
+  /// @return Returns partition number in case all rows of 'input' are
+  /// assigned to the same partition. In this case 'partitions' vector is left
+  /// unchanged. Used to optimize round-robin partitioning in local exchange.
+  virtual std::optional<int64_t> partition(
+      const RowVector& input,
+      std::vector<int64_t>& partitions) {
+    return std::nullopt;
+  }
 };
 
 /// Factory class for creating PartitionFunction instances.

--- a/velox/experimental/stateful/EventTimeTimerService.h
+++ b/velox/experimental/stateful/EventTimeTimerService.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "velox/experimental/stateful/InternalPriorityQueue.h"
+#include "velox/experimental/stateful/TimerHeapInternalTimer.h"
+#include "velox/experimental/stateful/Triggerable.h"
+
+namespace facebook::velox::stateful {
+
+// Manages event-time timers for a single operator. Timers are kept in a
+// priority queue ordered by timestamp. Triggering is driven externally by
+// watermark advancement via advanceWatermark().
+template <typename K, typename N>
+class EventTimeTimerService {
+ public:
+  explicit EventTimeTimerService(Triggerable<K, N>* triggerable)
+      : triggerable_(triggerable) {}
+
+  void registerTimer(const K& key, const N& ns, int64_t time) {
+    timersQueue_.add(TimerHeapInternalTimer<K, N>(time, key, ns));
+  }
+
+  void deleteTimer(const K& key, const N& ns, int64_t time) {
+    timersQueue_.remove(TimerHeapInternalTimer<K, N>(time, key, ns));
+  }
+
+  // Returns the timestamp of the earliest pending event-time timer, or 0 if
+  // no timer is registered. Preserves the original InternalTimerService
+  // semantics used by existing callers.
+  int64_t currentWatermark() {
+    if (timersQueue_.empty()) {
+      return 0;
+    }
+    return timersQueue_.peek().timestamp();
+  }
+
+  // Polls all event-time timers whose timestamp is <= the given watermark
+  // and dispatches them to the Triggerable.
+  void advanceWatermark(int64_t time) {
+    while (!timersQueue_.empty() && timersQueue_.peek().timestamp() <= time) {
+      TimerHeapInternalTimer<K, N> timer = timersQueue_.poll();
+      // Triggerable callbacks still take a shared_ptr; wrap the popped value.
+      triggerable_->onEventTime(
+          std::make_shared<TimerHeapInternalTimer<K, N>>(std::move(timer)));
+    }
+  }
+
+  void close() {
+    timersQueue_.clear();
+  }
+
+  bool empty() const {
+    return timersQueue_.empty();
+  }
+
+  size_t size() const {
+    return timersQueue_.size();
+  }
+
+ private:
+  Triggerable<K, N>* triggerable_;
+  HeapPriorityQueue<
+      TimerHeapInternalTimer<K, N>,
+      HeapTimerPriorityFn<K, N>,
+      /*kMaxQueue=*/false,
+      std::allocator<TimerHeapInternalTimer<K, N>>,
+      HeapTimerHasher<K, N>,
+      HeapTimerEquals<K, N>>
+      timersQueue_;
+};
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/GroupWindowAggregator.cpp
+++ b/velox/experimental/stateful/GroupWindowAggregator.cpp
@@ -83,12 +83,12 @@ void GroupWindowAggregator::advance() {
   }
 
   // 1. Partition input by key
-  std::map<uint32_t, RowVectorPtr> keyToData = keySelector_->partition(input_);
+  std::map<int64_t, RowVectorPtr> keyToData = keySelector_->partition(input_);
   for (const auto& [key, keyedData] : keyToData) {
     // 2. Set the current key in the context
     windowContext_->setCurrentKey(key);
     // 3. Partition the keyed data by rowtime or processing time
-    std::map<uint32_t, RowVectorPtr> timestampToData =
+    std::map<int64_t, RowVectorPtr> timestampToData =
         sliceAssigner_->assignSliceEnd(keyedData);
     for (const auto& [timestamp, data] : timestampToData) {
       // 4. Assign data to window

--- a/velox/experimental/stateful/InternalPriorityQueue.h
+++ b/velox/experimental/stateful/InternalPriorityQueue.h
@@ -15,78 +15,142 @@
  */
 #pragma once
 
-#include <algorithm>
-#include <vector>
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IndexedPriorityQueue.h"
 
 namespace facebook::velox::stateful {
 
+// Flink-style internal priority queue interface.
+//
 // This class is relevant to Flink InternalPriorityQueue.
 template <typename T>
 class InternalPriorityQueue {
  public:
-  virtual void add(T toAdd) = 0;
+  virtual ~InternalPriorityQueue() = default;
+
+  virtual bool add(const T& toAdd) = 0;
+
+  virtual bool add(T&& toAdd) = 0;
 
   virtual T poll() = 0;
 
-  virtual T peek() = 0;
+  virtual const T& peek() const = 0;
 
   virtual void clear() = 0;
+
+  virtual bool empty() const = 0;
+
+  virtual bool remove(const T& toRemove) = 0;
+
+  virtual size_t size() const = 0;
+
+  virtual bool contains(const T& value) const = 0;
 };
 
-// This class is relevant to Flink HeapPriorityQueue.
-// TODO: need to make it equal to Flink
-template <typename T>
-class HeapPriorityQueue : public InternalPriorityQueue<T> {
+// Heap-backed implementation of InternalPriorityQueue, layered on top of
+// velox::IndexedPriorityQueue without modifying the latter.
+//
+// Template parameters:
+//   - T: element type.
+//   - PriorityFn: callable producing an int64_t priority from a const T&.
+//                 The priority defines ordering; ties are broken by
+//                 IndexedPriorityQueue using insertion/update order (FIFO).
+//   - kMaxQueue: false for min-heap (default), true for max-heap.
+//   - Allocator/Hash/EqualTo: forwarded to IndexedPriorityQueue.
+//
+// CONTRACT for remove(value):
+//   The implementation evicts arbitrary values by reassigning their priority
+//   to a sentinel that is strictly more extreme than any real priority and
+//   then popping the head. Therefore:
+//     - For min-heap: real priorities MUST be > std::numeric_limits<int64_t>::min().
+//     - For max-heap: real priorities MUST be < std::numeric_limits<int64_t>::max().
+//   Timer services using timestamps satisfy this trivially.
+template <
+    typename T,
+    typename PriorityFn,
+    bool kMaxQueue = false,
+    typename Allocator = std::allocator<T>,
+    typename Hash = std::hash<T>,
+    typename EqualTo = std::equal_to<T>>
+class HeapPriorityQueue
+    : public InternalPriorityQueue<T>,
+      public velox::IndexedPriorityQueue<T, kMaxQueue, Allocator, Hash, EqualTo> {
  public:
-  HeapPriorityQueue() {
-    queue_.resize(1024); // Initial capacity, can be adjusted
+  using IndexedBase =
+      velox::IndexedPriorityQueue<T, kMaxQueue, Allocator, Hash, EqualTo>;
+
+  HeapPriorityQueue() = default;
+
+  explicit HeapPriorityQueue(
+      PriorityFn priorityFn,
+      const Allocator& allocator = {})
+      : IndexedBase(allocator), priorityFn_(std::move(priorityFn)) {}
+
+  // Adds an element. Returns true if the queue logically changed (new value
+  // inserted, or an existing value's priority changed); false if the value
+  // was already present with the same priority.
+  bool add(const T& value) override {
+    return IndexedBase::addOrUpdate(value, priorityFn_(value));
   }
 
-  void add(T toAdd) override {
-    // Implementation for adding to the priority queue set
-    queue_[size_] = toAdd;
-    size_++;
-    if (size_ >= queue_.size()) {
-      size_ = 0;
-    }
+  bool add(T&& value) override {
+    const int64_t priority = priorityFn_(value);
+    return IndexedBase::addOrUpdate(value, priority);
   }
 
+  // Returns and removes the head. Throws if empty.
   T poll() override {
-    // Implementation for polling from the priority queue set
-    size_--;
-    if (size_ < 0) {
-      size_ = queue_.size() - 1;
-    }
-    return queue_[size_];
+    VELOX_CHECK(!IndexedBase::empty(), "Cannot poll from an empty priority queue");
+    return IndexedBase::pop();
   }
 
-  T peek() override {
-    int index = size_ - 1;
-    if (index < 0) {
-      index = queue_.size() - 1;
-    }
-    return queue_[index];
+  // Returns the head without removing it. Throws if empty.
+  const T& peek() const override {
+    VELOX_CHECK(!IndexedBase::empty(), "Cannot peek from an empty priority queue");
+    return IndexedBase::top();
   }
 
+  // Removes the first occurrence of `value`. Returns true if removed.
+  // Complexity: O(log n) plus one extra percolate compared to a native
+  // remove-at-index implementation.
+  bool remove(const T& value) override {
+    const auto idx = IndexedBase::getValueIndex(value);
+    if (!idx.has_value()) {
+      return false;
+    }
+    constexpr int64_t kSentinel = kMaxQueue
+        ? std::numeric_limits<int64_t>::max()
+        : std::numeric_limits<int64_t>::min();
+    IndexedBase::updatePriority(idx.value(), kSentinel);
+    IndexedBase::pop();
+    return true;
+  }
+
+  // Removes all elements. Complexity: O(n log n).
   void clear() override {
-    queue_.clear();
-    size_ = 0;
+    while (!IndexedBase::empty()) {
+      IndexedBase::pop();
+    }
   }
 
-  void remove(T toRemove) {
-    // Implementation for removing an element from the priority queue set
-    auto it = std::find(queue_.begin(), queue_.end(), toRemove);
-    if (it != queue_.end()) {
-      *it = queue_[size_ - 1]; // Replace with the last element
-      size_--;
-      if (size_ < 0) {
-        size_ = queue_.size() - 1;
-      }
-    }
+  bool empty() const override {
+    return IndexedBase::empty();
+  }
+
+  size_t size() const override {
+    return static_cast<size_t>(IndexedBase::size());
+  }
+
+  bool contains(const T& value) const override {
+    return IndexedBase::getValueIndex(value).has_value();
   }
 
  private:
-  std::vector<T> queue_;
-  int size_ = 0;
+  PriorityFn priorityFn_{};
 };
+
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/InternalTimerService.h
+++ b/velox/experimental/stateful/InternalTimerService.h
@@ -15,66 +15,84 @@
  */
 #pragma once
 #include <cstdint>
+#include <memory>
 
-#include <velox/experimental/stateful/InternalPriorityQueue.h>
-#include <velox/experimental/stateful/TimerHeapInternalTimer.h>
-#include <velox/experimental/stateful/Triggerable.h>
+#include "velox/experimental/stateful/EventTimeTimerService.h"
+#include "velox/experimental/stateful/ProcessingTimeScheduler.h"
+#include "velox/experimental/stateful/ProcessingTimeTimerService.h"
+#include "velox/experimental/stateful/Triggerable.h"
 
 namespace facebook::velox::stateful {
 
 // This class is relevant to Flink InternalTimerServiceImpl.
+//
+// External facade kept for backward compatibility: one instance per operator
+// composes an EventTimeTimerService and a ProcessingTimeTimerService and
+// delegates the corresponding calls.
+//
+// Layout:
+//   InternalTimerService           <- facade
+//   ├── EventTimeTimerService      <- event-time queue + advanceWatermark
+//   └── ProcessingTimeTimerService <- processing-time queue + scheduling
 template <typename K, typename N>
 class InternalTimerService {
  public:
-  InternalTimerService(Triggerable<K, N>* triggerable)
-      : triggerable_(triggerable) {}
+  explicit InternalTimerService(Triggerable<K, N>* triggerable)
+      : eventTimeService_(triggerable),
+        processingTimeService_(
+            triggerable,
+            std::make_unique<SystemProcessingTimeScheduler>()) {}
 
-  void registerEventTimeTimer(K key, N ns, int64_t time) {
-    eventTimeTimersQueue_.add(
-        std::make_shared<TimerHeapInternalTimer<K, N>>(time, key, ns));
+  InternalTimerService(
+      Triggerable<K, N>* triggerable,
+      std::unique_ptr<ProcessingTimeScheduler> scheduler)
+      : eventTimeService_(triggerable),
+        processingTimeService_(triggerable, std::move(scheduler)) {}
+
+  void registerEventTimeTimer(const K& key, const N& ns, int64_t time) {
+    eventTimeService_.registerTimer(key, ns, time);
   }
 
-  void deleteEventTimeTimer(K key, N ns, int64_t time) {
-    eventTimeTimersQueue_.remove(
-        std::make_shared<TimerHeapInternalTimer<K, N>>(time, key, ns));
+  void deleteEventTimeTimer(const K& key, const N& ns, int64_t time) {
+    eventTimeService_.deleteTimer(key, ns, time);
   }
 
-  void registerProcessingTimeTimer(K key, N ns, int64_t time) {}
+  void registerProcessingTimeTimer(const K& key, const N& ns, int64_t time) {
+    processingTimeService_.registerTimer(key, ns, time);
+  }
 
-  void deleteProcessingTimeTimer(K key, N ns, int64_t time) {
-    eventTimeTimersQueue_.remove(
-        std::make_shared<TimerHeapInternalTimer<K, N>>(time, key, ns));
+  void deleteProcessingTimeTimer(const K& key, const N& ns, int64_t time) {
+    processingTimeService_.deleteTimer(key, ns, time);
   }
 
   int64_t currentWatermark() {
-    // TODO: Implement watermark logic if needed.
-    if (eventTimeTimersQueue_.peek() != nullptr) {
-      return eventTimeTimersQueue_.peek()->timestamp();
-    }
-    return 0; // or some other default value
+    return eventTimeService_.currentWatermark();
   }
 
   int64_t currentProcessingTime() {
-    // TODO: Implement processing time logic if needed.
-    return 0; // or some other default value
+    return processingTimeService_.currentProcessingTime();
   }
 
   void advanceWatermark(int64_t time) {
-    while (eventTimeTimersQueue_.peek() != nullptr &&
-           eventTimeTimersQueue_.peek()->timestamp() <= time) {
-      auto timer = eventTimeTimersQueue_.poll();
-      triggerable_->onEventTime(timer);
-    }
+    eventTimeService_.advanceWatermark(time);
   }
 
   void close() {
-    eventTimeTimersQueue_.clear();
+    eventTimeService_.close();
+    processingTimeService_.close();
+  }
+
+  EventTimeTimerService<K, N>& eventTimeTimerService() {
+    return eventTimeService_;
+  }
+
+  ProcessingTimeTimerService<K, N>& processingTimeTimerService() {
+    return processingTimeService_;
   }
 
  private:
-  Triggerable<K, N>* triggerable_;
-  HeapPriorityQueue<std::shared_ptr<TimerHeapInternalTimer<K, N>>>
-      eventTimeTimersQueue_;
+  EventTimeTimerService<K, N> eventTimeService_;
+  ProcessingTimeTimerService<K, N> processingTimeService_;
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/KeySelector.cpp
+++ b/velox/experimental/stateful/KeySelector.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/experimental/stateful/KeySelector.h"
+#include "velox/experimental/stateful/window/WindowPartitionFunction.h"
 
 namespace facebook::velox::stateful {
 
@@ -25,24 +26,37 @@ KeySelector::KeySelector(
       pool_(pool),
       numPartitions_(numPartitions) {}
 
-std::map<uint32_t, RowVectorPtr> KeySelector::partition(
+std::map<int64_t, RowVectorPtr> KeySelector::partition(
     const RowVectorPtr& input) {
   if (numPartitions_ == 1) {
-    return std::map<uint32_t, RowVectorPtr>{{0, input}};
+    return std::map<int64_t, RowVectorPtr>{{0, input}};
   }
   prepareForInput(input);
 
   // TODO: The partition function doesn't use max parallelism.
-  std::vector<uint32_t> partitions(input->size());
-  auto part = partitionFunction_->partition(*input, partitions);
-  if (part) {
+  std::vector<int64_t> partitions(input->size());
+  std::optional<int64_t> res;
+  auto windowPartitionFunction = dynamic_cast<WindowPartitionFunction*>(partitionFunction_.get());
+  if (windowPartitionFunction) {
+    res = windowPartitionFunction->partition(*input, partitions);
+  } else {
+    std::vector<uint32_t> tmpPartitions(input->size());
+    std::optional<uint32_t> tmpRes = partitionFunction_->partition(*input, tmpPartitions);
+    if (tmpRes) {
+      res = static_cast<int64_t>(*tmpRes);
+    }
+    for (vector_size_t i = 0; i < tmpPartitions.size(); ++i) {
+      partitions[i] = static_cast<int64_t>(tmpPartitions[i]);
+    }
+  }
+  if (res) {
     // TODO: this is a optimization, as the RowVector may have be partitioned in
     // local aggregation, so need not to partition again in global agg, but need
     // to verify whether the judge condition is enough.
-    return std::map<uint32_t, RowVectorPtr>{{*part, input}};
+    return std::map<int64_t, RowVectorPtr>{{*res, input}};
   }
   const auto numInput = input->size();
-  std::map<uint32_t, vector_size_t> numOfKeys;
+  std::map<int64_t, vector_size_t> numOfKeys;
   for (auto i = 0; i < numInput; ++i) {
     if (numOfKeys.count(partitions[i]) == 0) {
       numOfKeys[partitions[i]] = 1;
@@ -51,8 +65,8 @@ std::map<uint32_t, RowVectorPtr> KeySelector::partition(
     }
   }
 
-  std::map<uint32_t, BufferPtr> keyToIndexBuffers;
-  std::map<uint32_t, vector_size_t*> keyToRawIndices;
+  std::map<int64_t, BufferPtr> keyToIndexBuffers;
+  std::map<int64_t, vector_size_t*> keyToRawIndices;
   allocateIndexBuffers(numOfKeys, keyToIndexBuffers, keyToRawIndices);
 
   numOfKeys.clear();
@@ -66,7 +80,7 @@ std::map<uint32_t, RowVectorPtr> KeySelector::partition(
     numOfKeys[partition] = index + 1;
   }
 
-  std::map<uint32_t, RowVectorPtr> results;
+  std::map<int64_t, RowVectorPtr> results;
   for (auto& [key, partitionSize] : numOfKeys) {
     auto partitionData =
         wrapChildren(input, partitionSize, keyToIndexBuffers[key]);
@@ -86,9 +100,9 @@ void KeySelector::prepareForInput(const RowVectorPtr& input) {
 }
 
 void KeySelector::allocateIndexBuffers(
-    const std::map<uint32_t, vector_size_t>& numOfKeys,
-    std::map<uint32_t, BufferPtr>& keyToIndexBuffers,
-    std::map<uint32_t, vector_size_t*>& keyToRawIndices) {
+    const std::map<int64_t, vector_size_t>& numOfKeys,
+    std::map<int64_t, BufferPtr>& keyToIndexBuffers,
+    std::map<int64_t, vector_size_t*>& keyToRawIndices) {
   for (auto& [key, num] : numOfKeys) {
     keyToIndexBuffers[key] = allocateIndices(num, pool_);
     keyToRawIndices[key] = keyToIndexBuffers[key]->asMutable<vector_size_t>();

--- a/velox/experimental/stateful/KeySelector.h
+++ b/velox/experimental/stateful/KeySelector.h
@@ -31,15 +31,15 @@ class KeySelector {
       memory::MemoryPool* pool,
       int numPartitions = INT_MAX);
 
-  std::map<uint32_t, RowVectorPtr> partition(const RowVectorPtr& input);
+  std::map<int64_t, RowVectorPtr> partition(const RowVectorPtr& input);
 
  private:
   void prepareForInput(const RowVectorPtr& input);
 
   void allocateIndexBuffers(
-      const std::map<uint32_t, vector_size_t>& numOfKeys,
-      std::map<uint32_t, BufferPtr>& keyToIndexBuffers,
-      std::map<uint32_t, vector_size_t*>& keyToRawIndices);
+      const std::map<int64_t, vector_size_t>& numOfKeys,
+      std::map<int64_t, BufferPtr>& keyToIndexBuffers,
+      std::map<int64_t, vector_size_t*>& keyToRawIndices);
 
   RowVectorPtr wrapChildren(
       const RowVectorPtr& input,

--- a/velox/experimental/stateful/LocalWindowAggregator.cpp
+++ b/velox/experimental/stateful/LocalWindowAggregator.cpp
@@ -47,9 +47,9 @@ void LocalWindowAggregator::advance() {
     return;
   }
 
-  std::map<uint32_t, RowVectorPtr> keyToData = keySelector_->partition(input_);
+  std::map<int64_t, RowVectorPtr> keyToData = keySelector_->partition(input_);
   for (const auto& [key, data] : keyToData) {
-    std::map<uint32_t, RowVectorPtr> sliceEndToData =
+    std::map<int64_t, RowVectorPtr> sliceEndToData =
         sliceAssigner_->partition(data);
     for (const auto& [sliceEnd, data] : sliceEndToData) {
       // TODO: addElement may have data output.

--- a/velox/experimental/stateful/ProcessingTimeScheduler.h
+++ b/velox/experimental/stateful/ProcessingTimeScheduler.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/executors/FunctionScheduler.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <chrono>
+#include <functional>
+#include <optional>
+#include <set>
+#include <string>
+
+#include "velox/experimental/stateful/window/TimeWindowUtil.h"
+
+namespace facebook::velox::stateful {
+
+using ProcessingTimeCallback = std::function<void(int64_t)>;
+
+// A task scheduled to run at a specific wall-clock timestamp.
+class ProcessingTimerTask {
+ public:
+  ProcessingTimerTask(int64_t time, ProcessingTimeCallback callback)
+      : time_(time), callback_(std::move(callback)) {}
+
+  void operator()() const {
+    callback_(time_);
+  }
+
+ private:
+  int64_t time_;
+  ProcessingTimeCallback callback_;
+};
+
+// Low-level scheduler abstraction: arranges for a callback to fire at a
+// given wall-clock timestamp. This is the underlying timing primitive used
+// by the higher-level ProcessingTimeTimerService and corresponds to Flink's
+// org.apache.flink.streaming.runtime.tasks.ProcessingTimeService interface.
+class ProcessingTimeScheduler {
+ public:
+  virtual ~ProcessingTimeScheduler() = default;
+
+  int64_t getCurrentProcessingTime() {
+    return TimeWindowUtil::getCurrentProcessingTime();
+  }
+
+  virtual std::optional<std::string> registerTimer(
+      int64_t timestamp,
+      ProcessingTimerTask target) = 0;
+  virtual void cancel(const std::string& /*task*/) {}
+  virtual void close() {}
+
+  void unregister(const std::string& task) {
+    auto it = std::find(registry_.begin(), registry_.end(), task);
+    if (it != registry_.end()) {
+      registry_.erase(it);
+    }
+  }
+
+  std::string generateTimerTaskName(int64_t timestamp) {
+    // boost::uuids::random_generator's constructor is expensive (it opens
+    // /dev/urandom to seed its underlying RNG) and the generator itself is
+    // not thread-safe. A function-local static thread_local instance gives
+    // each thread its own generator, constructed lazily once.
+    static thread_local boost::uuids::random_generator generator;
+    boost::uuids::uuid uuid = generator();
+    return "proc_time_task_" + std::to_string(timestamp) + "-" +
+        to_string(uuid);
+  }
+
+ protected:
+  std::set<std::string> registry_;
+};
+
+// Concrete scheduler backed by a folly::FunctionScheduler running tasks on a
+// background thread when the wall-clock deadline is reached.
+class SystemProcessingTimeScheduler : public ProcessingTimeScheduler {
+ public:
+  SystemProcessingTimeScheduler() : ProcessingTimeScheduler() {
+    executor_ = std::make_unique<folly::FunctionScheduler>();
+    executor_->start();
+  }
+
+  std::optional<std::string> registerTimer(
+      int64_t timestamp,
+      ProcessingTimerTask task) override {
+    int64_t currentTimestamp = getCurrentProcessingTime();
+    int64_t delay = 0;
+    if (timestamp >= currentTimestamp) {
+      delay = timestamp - currentTimestamp;
+    }
+    std::string taskName = generateTimerTaskName(timestamp);
+    if (delay > 0) {
+      executor_->addFunctionOnce(
+          std::move(task), taskName, std::chrono::microseconds(delay * 1000));
+      registry_.emplace(taskName);
+    } else {
+      task();
+    }
+    return std::make_optional<std::string>(taskName);
+  }
+
+  void cancel(const std::string& task) override {
+    auto it = std::find(registry_.begin(), registry_.end(), task);
+    if (it != registry_.end()) {
+      executor_->cancelFunction(task);
+      registry_.erase(it);
+    }
+  }
+
+  void close() override {
+    if (executor_) {
+      executor_->shutdown();
+    }
+    registry_.clear();
+  }
+
+ private:
+  std::unique_ptr<folly::FunctionScheduler> executor_;
+};
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/ProcessingTimeTimerService.h
+++ b/velox/experimental/stateful/ProcessingTimeTimerService.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "velox/experimental/stateful/InternalPriorityQueue.h"
+#include "velox/experimental/stateful/ProcessingTimeScheduler.h"
+#include "velox/experimental/stateful/TimerHeapInternalTimer.h"
+#include "velox/experimental/stateful/Triggerable.h"
+
+namespace facebook::velox::stateful {
+
+// Manages processing-time timers for a single operator. Pending timers are
+// kept in a priority queue ordered by timestamp; the head of the queue is
+// scheduled with the underlying ProcessingTimeScheduler so it fires at its
+// wall-clock time. When the timer fires, all timers due at that moment are
+// drained and forwarded to the Triggerable.
+template <typename K, typename N>
+class ProcessingTimeTimerService {
+ public:
+  ProcessingTimeTimerService(
+      Triggerable<K, N>* triggerable,
+      std::unique_ptr<ProcessingTimeScheduler> scheduler)
+      : triggerable_(triggerable), scheduler_(std::move(scheduler)) {}
+
+  void registerTimer(K key, N ns, int64_t time) {
+    // Capture the timestamp of the current head before insertion. If the
+    // queue is empty, treat as +inf so the new timer is unconditionally the
+    // head.
+    const int64_t oldHeadTimestamp = timersQueue_.empty()
+        ? std::numeric_limits<int64_t>::max()
+        : timersQueue_.peek().timestamp();
+    if (timersQueue_.add(TimerHeapInternalTimer<K, N>(time, key, ns))) {
+      if (time < oldHeadTimestamp) {
+        if (nextTimer_.has_value()) {
+          scheduler_->cancel(nextTimer_.value());
+        }
+        nextTimer_ = scheduler_->registerTimer(
+            time, ProcessingTimerTask(time, [this](int64_t processingTime) {
+              onProcessingTime(processingTime);
+            }));
+      }
+    }
+  }
+
+  void deleteTimer(K key, N ns, int64_t time) {
+    timersQueue_.remove(TimerHeapInternalTimer<K, N>(time, key, ns));
+  }
+
+  int64_t currentProcessingTime() {
+    if (scheduler_) {
+      return scheduler_->getCurrentProcessingTime();
+    }
+    return 0;
+  }
+
+  void close() {
+    timersQueue_.clear();
+    if (scheduler_) {
+      scheduler_->close();
+    }
+  }
+
+  bool empty() const {
+    return timersQueue_.empty();
+  }
+
+  size_t size() const {
+    return timersQueue_.size();
+  }
+
+ private:
+  // Invoked by the ProcessingTimeScheduler when the scheduled wall-clock
+  // timestamp is reached. Drains all due timers under the Triggerable's
+  // mutex and re-arms the scheduler for the next head if any.
+  void onProcessingTime(int64_t time) {
+    std::string taskName;
+    if (nextTimer_.has_value()) {
+      taskName = nextTimer_.value();
+    }
+    nextTimer_ = std::nullopt;
+
+    // Timestamp of the next pending timer that was NOT due (head after the
+    // drain). std::nullopt means the queue is empty after draining.
+    std::optional<int64_t> nextHeadTimestamp;
+    bool keepDraining = true;
+    const std::shared_ptr<std::mutex> mtx = triggerable_->getMutex();
+    if (mtx) {
+      std::lock_guard<std::mutex> lock(*mtx);
+      while (keepDraining && !timersQueue_.empty()) {
+        const auto& head = timersQueue_.peek();
+        if (head.timestamp() > time) {
+          nextHeadTimestamp = head.timestamp();
+          keepDraining = false;
+          continue;
+        }
+        TimerHeapInternalTimer<K, N> popped = timersQueue_.poll();
+        // Triggerable callbacks still take a shared_ptr; wrap the popped value.
+        triggerable_->onProcessingTime(
+            std::make_shared<TimerHeapInternalTimer<K, N>>(std::move(popped)));
+      }
+      if (!taskName.empty()) {
+        scheduler_->unregister(taskName);
+      }
+    }
+
+    if (nextHeadTimestamp.has_value() && !nextTimer_.has_value()) {
+      const int64_t ts = *nextHeadTimestamp;
+      nextTimer_ = scheduler_->registerTimer(
+          ts, ProcessingTimerTask(ts, [this](int64_t processingTime) {
+            onProcessingTime(processingTime);
+          }));
+    }
+  }
+
+  Triggerable<K, N>* triggerable_;
+  std::unique_ptr<ProcessingTimeScheduler> scheduler_;
+  std::optional<std::string> nextTimer_;
+  HeapPriorityQueue<
+      TimerHeapInternalTimer<K, N>,
+      HeapTimerPriorityFn<K, N>,
+      /*kMaxQueue=*/false,
+      std::allocator<TimerHeapInternalTimer<K, N>>,
+      HeapTimerHasher<K, N>,
+      HeapTimerEquals<K, N>>
+      timersQueue_;
+};
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/StatefulPlanner.cpp
+++ b/velox/experimental/stateful/StatefulPlanner.cpp
@@ -277,7 +277,7 @@ StatefulOperatorPtr StatefulPlanner::transformStreamWindowAggregationOperator(
             windowAggNode->size(),
             windowAggNode->step(),
             windowAggNode->offset(),
-            windowAggNode->windowType(),
+            Window::getType(windowAggNode->windowType()),
             windowAggNode->rowtimeIndex());
     return std::make_unique<WindowAggregator>(
         std::move(localAggregator),
@@ -312,7 +312,7 @@ StatefulOperatorPtr StatefulPlanner::transformGroupWindowAggregationOperator(
           0,
           0,
           0,
-          windowAggNode->windowType(),
+          Window::getType(windowAggNode->windowType()),
           windowAggNode->rowtimeIndex());
 
   return std::make_unique<GroupWindowAggregator>(

--- a/velox/experimental/stateful/TimerHeapInternalTimer.h
+++ b/velox/experimental/stateful/TimerHeapInternalTimer.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #pragma once
+#include "velox/common/base/BitUtil.h"
 #include <cstdint>
 
 namespace facebook::velox::stateful {
@@ -22,22 +23,22 @@ namespace facebook::velox::stateful {
 template <typename K, typename N>
 class TimerHeapInternalTimer {
  public:
-  TimerHeapInternalTimer(int64_t timestamp, K key, N ns)
+  TimerHeapInternalTimer(int64_t timestamp, const K& key, const N& ns)
       : timestamp_(timestamp), key_(key), ns_(ns), keyGroupIndex_(0) {}
 
-  int64_t timestamp() {
+  int64_t timestamp() const {
     return timestamp_;
   }
 
-  K key() {
+  const K& key() const {
     return key_;
   }
 
-  N ns() {
+  const N& ns() const {
     return ns_;
   }
 
-  int keyGroupIndex() {
+  int keyGroupIndex() const {
     return keyGroupIndex_;
   }
 
@@ -51,6 +52,44 @@ class TimerHeapInternalTimer {
   K key_;
   N ns_;
   int keyGroupIndex_;
+};
+
+// Hash/Equal/Comparator/PriorityFn functors operate on TimerHeapInternalTimer
+// values directly (no shared_ptr indirection), so they can be used with a
+// HeapPriorityQueue whose element type is TimerHeapInternalTimer<K, N>.
+template <typename K, typename N>
+struct HeapTimerHasher {
+  size_t operator()(const TimerHeapInternalTimer<K, N>& a) const {
+    return bits::hashMix(a.timestamp(), a.key());
+  }
+};
+
+template <typename K, typename N>
+struct HeapTimerEquals {
+  bool operator()(
+      const TimerHeapInternalTimer<K, N>& a,
+      const TimerHeapInternalTimer<K, N>& b) const {
+    return a == b;
+  }
+};
+
+template <typename K, typename N>
+struct HeapTimerComparator {
+  bool operator()(
+      const TimerHeapInternalTimer<K, N>& a,
+      const TimerHeapInternalTimer<K, N>& b) const {
+    return a.timestamp() < b.timestamp();
+  }
+};
+
+// Priority extractor used with HeapPriorityQueue (which is layered on
+// IndexedPriorityQueue). Returning timestamp as the priority yields a
+// min-heap whose head is the earliest pending timer.
+template <typename K, typename N>
+struct HeapTimerPriorityFn {
+  int64_t operator()(const TimerHeapInternalTimer<K, N>& timer) const {
+    return timer.timestamp();
+  }
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/Triggerable.h
+++ b/velox/experimental/stateful/Triggerable.h
@@ -26,8 +26,20 @@ namespace facebook::velox::stateful {
 template <typename K, typename N>
 class Triggerable {
  public:
+  Triggerable() {
+    mtx_ = std::make_shared<std::mutex>();
+  }
+
   virtual void onEventTime(
       std::shared_ptr<TimerHeapInternalTimer<K, N>> timer) = 0;
+
+  virtual void onProcessingTime(
+      std::shared_ptr<TimerHeapInternalTimer<K, N>> timer) {}
+  
+  const std::shared_ptr<std::mutex> getMutex() { return mtx_; }
+
+protected:
+  std::shared_ptr<std::mutex> mtx_;
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WindowAggregator.cpp
+++ b/velox/experimental/stateful/WindowAggregator.cpp
@@ -60,16 +60,14 @@ void WindowAggregator::advance() {
     return;
   }
 
-  std::map<uint32_t, RowVectorPtr> keyToData = keySelector_->partition(input_);
+  std::map<int64_t, RowVectorPtr> keyToData = keySelector_->partition(input_);
   for (const auto& [key, data] : keyToData) {
-    std::map<uint32_t, RowVectorPtr> sliceEndToData =
+    std::map<int64_t, RowVectorPtr> sliceEndToData =
         sliceAssigner_->assignSliceEnd(data);
     for (const auto& [sliceEnd, data] : sliceEndToData) {
       auto windowData = data;
       if (!isEventTime) {
-        // TODO: support processing time
-        // windowTimerService_->registerProcessingTimeWindowTimer(sliceEnd,
-        // sliceEnd - 1);
+        windowTimerService_->registerProcessingTimeTimer(key, sliceEnd, sliceEnd);
       }
 
       if (isEventTime &&
@@ -155,7 +153,7 @@ void WindowAggregator::processWatermarkInternal(int64_t timestamp) {
 }
 
 void WindowAggregator::onEventTime(
-    std::shared_ptr<TimerHeapInternalTimer<uint32_t, int64_t>> timer) {
+    std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>> timer) {
   auto output = windowState_->value(timer->key(), timer->ns());
   windowState_->remove(timer->key(), timer->ns());
   pushOutput(
@@ -167,11 +165,88 @@ int64_t WindowAggregator::sliceStateMergeTarget(int64_t sliceToMerge) {
   return sliceToMerge;
 }
 
+/// Add window_start / window_end timestamp to output
+RowVectorPtr addWindowTimestampToOutput(
+  const RowVectorPtr& output,
+  const std::string& fieldName,
+  const int64_t fieldValue,
+  const int32_t fieldIndex) {
+  /// TODO: implement it
+  VELOX_NYI();
+}
+
+void WindowAggregator::onTimer(std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>> timer) {
+  fireWindow(timer->key(), timer->timestamp(), timer->ns());
+  clearWindow(timer->key(), timer->timestamp(), timer->ns());
+}
+
+template<typename K>
+void WindowAggregator::fireWindow(const K& key, int64_t timerTimestamp, int64_t windowEnd) {
+  RowVectorPtr output = windowState_->value(key, windowEnd);
+  if (!output) {
+    LOG(INFO) << "No output found for key: " << key << ", window end: " << windowEnd;
+    return;
+  } else {
+    if (windowStartIndex_ >= 0) {
+      output = addWindowTimestampToOutput(
+        output,
+        "window_start",
+        windowEnd - windowInterval_,
+        windowStartIndex_);
+    }
+    if (windowEndIndex_ >= 0) {
+      output = addWindowTimestampToOutput(
+        output,
+      "window_end",
+      windowEnd,
+      windowEndIndex_);
+    }
+  }
+  if (output) {
+    pushOutput(std::make_shared<StreamRecord>(getPlanNodeId(), std::move(output)));
+  }
+}
+
+template<typename K>
+void WindowAggregator::clearWindow(const K& key, int64_t timerTimestamp, int64_t windowEnd) {
+  windowState_->remove(key, windowEnd);
+}
+
+void WindowAggregator::onProcessingTime(std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>> timer) {
+  if (timer->timestamp() > lastTriggeredProcessingTime_) {
+    lastTriggeredProcessingTime_ = timer->timestamp();
+    auto windowKeyToData = windowBuffer_->advanceProgress(timer->timestamp());
+    for (auto& [windowKey, datas] : windowKeyToData) {
+      if (datas.empty()) {
+        continue;
+      }
+      // std::list<RowVectorPtr> allDatas(datas.begin(), datas.end());
+      auto stateAcc = windowState_->value(windowKey.key(), windowKey.window());
+      if (stateAcc) {
+        datas.push_back(stateAcc);
+      }
+      RowVectorPtr opInput = TimeWindowUtil::mergeVectors(datas, op()->pool());
+      op()->addInput(opInput);
+      auto newAcc = op()->getOutput();
+      if (newAcc) {
+        windowState_->update(windowKey.key(), windowKey.window(), newAcc);
+      }
+    }
+    if (!windowKeyToData.empty()) {
+      windowBuffer_->clear();
+    }
+  }
+  onTimer(timer);
+}
+
 void WindowAggregator::close() {
   processWatermarkInternal(INT_MAX);
   StatefulOperator::close();
-  localAggerator_->close();
+  if (localAggerator_) {
+    localAggerator_->close();
+  }
   input_.reset();
+  windowTimerService_->close();
   windowBuffer_->clear();
   windowState_->clear();
   currentProgress_ = 0;

--- a/velox/experimental/stateful/WindowAggregator.h
+++ b/velox/experimental/stateful/WindowAggregator.h
@@ -30,7 +30,7 @@ namespace facebook::velox::stateful {
 /// This class is related to XXXWindowAggProcessor in Flink.
 /// Its work includes both WindowAggOperator and XXXWindowAggOperator.
 class WindowAggregator : public StatefulOperator,
-                         public Triggerable<uint32_t, int64_t> {
+                         public Triggerable<int64_t, int64_t> {
  public:
   WindowAggregator(
       std::unique_ptr<exec::Operator> localAggerator,
@@ -55,13 +55,23 @@ class WindowAggregator : public StatefulOperator,
     return "WindowAggregator";
   }
 
-  void onEventTime(std::shared_ptr<TimerHeapInternalTimer<uint32_t, int64_t>>
+  void onEventTime(std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>>
                        timer) override;
+
+  void onProcessingTime(std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>> timer) override;
 
  private:
   void processWatermarkInternal(int64_t timestamp);
 
   int64_t sliceStateMergeTarget(int64_t sliceToMerge);
+
+  void onTimer(std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>> timer);
+
+  template<typename K>
+  void fireWindow(const K& key, int64_t timerTimestamp, int64_t windowEnd);
+
+  template<typename K>
+  void clearWindow(const K& key, int64_t timerTimestamp, int64_t windowEnd);
 
   std::unique_ptr<exec::Operator> localAggerator_;
   std::unique_ptr<KeySelector> keySelector_;
@@ -71,11 +81,14 @@ class WindowAggregator : public StatefulOperator,
   const bool useDayLightSaving_;
   const int shiftTimeZone_ = 0; // TODO: support time zone shift
   const bool isEventTime = true; // TODO: support processing time
+  const int32_t windowStartIndex_ = -1;
+  const int32_t windowEndIndex_ = -1;
 
   RowVectorPtr input_;
   int64_t currentProgress_ = 0;
   int64_t nextTriggerWatermark_ = 0;
+  int64_t lastTriggeredProcessingTime_ = 0;
   std::shared_ptr<ValueState<uint32_t, int64_t, RowVectorPtr>> windowState_;
-  std::shared_ptr<InternalTimerService<uint32_t, int64_t>> windowTimerService_;
+  std::shared_ptr<InternalTimerService<int64_t, int64_t>> windowTimerService_;
 };
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WindowJoin.cpp
+++ b/velox/experimental/stateful/WindowJoin.cpp
@@ -119,7 +119,7 @@ std::map<int64_t, RowVectorPtr> WindowJoin::partitionWindowData(
 }
 
 void WindowJoin::onEventTime(
-    std::shared_ptr<TimerHeapInternalTimer<uint32_t, int64_t>> timer) {
+    std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>> timer) {
   join(timer->key(), timer->ns());
 }
 

--- a/velox/experimental/stateful/WindowJoin.h
+++ b/velox/experimental/stateful/WindowJoin.h
@@ -29,7 +29,7 @@
     namespace facebook::velox::stateful {
 
   class WindowJoin : public StatefulOperator,
-                     public Triggerable<uint32_t, int64_t> {
+                     public Triggerable<int64_t, int64_t> {
    public:
     WindowJoin(
         std::unique_ptr<exec::Operator> leftInput,
@@ -57,7 +57,7 @@
       return "WindowJoin";
     }
 
-    void onEventTime(std::shared_ptr<TimerHeapInternalTimer<uint32_t, int64_t>>
+    void onEventTime(std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>>
                          timer) override;
 
    protected:
@@ -93,7 +93,7 @@
         rightWindowState_;
     const int leftWindowEndIndex_;
     const int rightWindowEndIndex_;
-    std::shared_ptr<InternalTimerService<uint32_t, int64_t>> timerService_;
+    std::shared_ptr<InternalTimerService<int64_t, int64_t>> timerService_;
   };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/state/HeapKeyedStateBackend.cpp
+++ b/velox/experimental/stateful/state/HeapKeyedStateBackend.cpp
@@ -106,10 +106,10 @@ HeapKeyedStateBackend::getOrCreateRankMapState(
   return state;
 }
 
-std::shared_ptr<InternalTimerService<uint32_t, int64_t>>
+std::shared_ptr<InternalTimerService<int64_t, int64_t>>
 HeapKeyedStateBackend::createTimerService(
-    Triggerable<uint32_t, int64_t>* triggerable) {
-  return std::make_shared<InternalTimerService<uint32_t, int64_t>>(triggerable);
+    Triggerable<int64_t, int64_t>* triggerable) {
+  return std::make_shared<InternalTimerService<int64_t, int64_t>>(triggerable);
 }
 
 std::shared_ptr<InternalTimerService<uint32_t, TimeWindow>>

--- a/velox/experimental/stateful/state/HeapKeyedStateBackend.h
+++ b/velox/experimental/stateful/state/HeapKeyedStateBackend.h
@@ -33,8 +33,8 @@ class HeapKeyedStateBackend : public KeyedStateBackend {
   std::shared_ptr<ValueState<uint32_t, int64_t, RowVectorPtr>>
   getOrCreateValueState(StateDescriptor& stateDescriptor) override;
 
-  std::shared_ptr<InternalTimerService<uint32_t, int64_t>> createTimerService(
-      Triggerable<uint32_t, int64_t>* triggerable) override;
+  std::shared_ptr<InternalTimerService<int64_t, int64_t>> createTimerService(
+      Triggerable<int64_t, int64_t>* triggerable) override;
 
   std::shared_ptr<ValueState<uint32_t, TimeWindow, RowVectorPtr>>
   getOrCreateGroupValueState(StateDescriptor& stateDescriptor) override;

--- a/velox/experimental/stateful/state/KeyedStateBackend.h
+++ b/velox/experimental/stateful/state/KeyedStateBackend.h
@@ -49,8 +49,8 @@ class KeyedStateBackend : public Snapshotable, public CheckpointListener {
   getOrCreateRankMapState(StateDescriptor& stateDescriptor) = 0;
 
   // TODO: Flink create PriorityQueue.
-  virtual std::shared_ptr<InternalTimerService<uint32_t, int64_t>>
-  createTimerService(Triggerable<uint32_t, int64_t>* triggerable) = 0;
+  virtual std::shared_ptr<InternalTimerService<int64_t, int64_t>>
+  createTimerService(Triggerable<int64_t, int64_t>* triggerable) = 0;
 
   virtual std::shared_ptr<InternalTimerService<uint32_t, TimeWindow>>
   createGroupWindowAggTimerService(

--- a/velox/experimental/stateful/state/RocksDBKeyedStateBackend.cpp
+++ b/velox/experimental/stateful/state/RocksDBKeyedStateBackend.cpp
@@ -178,10 +178,10 @@ RocksDBKeyedStateBackend::getOrCreateRankMapState(
   return nullptr;
 }
 
-std::shared_ptr<InternalTimerService<uint32_t, int64_t>>
+std::shared_ptr<InternalTimerService<int64_t, int64_t>>
 RocksDBKeyedStateBackend::createTimerService(
-    Triggerable<uint32_t, int64_t>* triggerable) {
-  return std::make_shared<InternalTimerService<uint32_t, int64_t>>(triggerable);
+    Triggerable<int64_t, int64_t>* triggerable) {
+  return std::make_shared<InternalTimerService<int64_t, int64_t>>(triggerable);
 }
 
 std::shared_ptr<InternalTimerService<uint32_t, TimeWindow>>

--- a/velox/experimental/stateful/state/RocksDBKeyedStateBackend.h
+++ b/velox/experimental/stateful/state/RocksDBKeyedStateBackend.h
@@ -58,8 +58,8 @@ class RocksDBKeyedStateBackend : public KeyedStateBackend {
   std::shared_ptr<MapState<uint32_t, int, uint32_t, RowVectorPtr>>
   getOrCreateRankMapState(StateDescriptor& stateDescriptor) override;
 
-  std::shared_ptr<InternalTimerService<uint32_t, int64_t>> createTimerService(
-      Triggerable<uint32_t, int64_t>* triggerable) override;
+  std::shared_ptr<InternalTimerService<int64_t, int64_t>> createTimerService(
+      Triggerable<int64_t, int64_t>* triggerable) override;
 
   std::shared_ptr<InternalTimerService<uint32_t, TimeWindow>>
   createGroupWindowAggTimerService(

--- a/velox/experimental/stateful/state/StateEntry.h
+++ b/velox/experimental/stateful/state/StateEntry.h
@@ -27,7 +27,7 @@ namespace facebook::velox::stateful {
 template <typename K, typename N, typename S>
 class StateEntry {
  public:
-  StateEntry(K key, N ns, S state)
+  StateEntry(const K& key, const N& ns, const S& state)
       : key_(std::move(key)), namespace_(ns), state_(std::move(state)) {}
 
   K getKey() {

--- a/velox/experimental/stateful/state/StateMap.h
+++ b/velox/experimental/stateful/state/StateMap.h
@@ -36,7 +36,7 @@ class StateMap {
     tempTable_.resize(1024);
   }
 
-  S get(K key, N ns) {
+  S get(const K& key, const N& ns) {
     auto hash = (std::hash<K>{}(key) + std::hash<N>{}(ns)) % tempTable_.size();
     if (tempTable_[hash] != nullptr && tempTable_[hash]->getKey() == key &&
         tempTable_[hash]->getNamespace() == ns) {
@@ -45,13 +45,13 @@ class StateMap {
     return S(); // Return default state if not found
   }
 
-  void put(K key, N ns, S state) {
+  void put(const K& key, const N& ns, const S& state) {
     // TODO: add enlarge logic.
     auto hash = (std::hash<K>{}(key) + std::hash<N>{}(ns)) % tempTable_.size();
     tempTable_[hash] = std::make_shared<StateEntry<K, N, S>>(key, ns, state);
   }
 
-  void remove(K key, N ns) {
+  void remove(const K& key, const N& ns) {
     auto hash = (std::hash<K>{}(key) + std::hash<N>{}(ns)) % tempTable_.size();
     if (tempTable_[hash] != nullptr && tempTable_[hash]->getKey() == key &&
         tempTable_[hash]->getNamespace() == ns) {

--- a/velox/experimental/stateful/state/StateTable.h
+++ b/velox/experimental/stateful/state/StateTable.h
@@ -36,17 +36,17 @@ class StateTable {
   StateTable(int keyGroupNumber)
       : keyGroupedStates_(keyGroupNumber), keyGroupNumber_(keyGroupNumber) {}
 
-  S get(K key, N ns) {
+  S get(const K& key, const N& ns) {
     int keyGroupIndex = std::hash<K>()(key) % keyGroupNumber_;
     return keyGroupedStates_[keyGroupIndex].get(key, ns);
   }
 
-  void put(K key, N ns, S state) {
+  void put(const K& key, const N& ns, const S& state) {
     int keyGroupIndex = std::hash<K>()(key) % keyGroupNumber_;
     keyGroupedStates_[keyGroupIndex].put(key, ns, state);
   }
 
-  void remove(K key, N ns) {
+  void remove(const K& key, const N& ns) {
     int keyGroupIndex = std::hash<K>()(key) % keyGroupNumber_;
     keyGroupedStates_[keyGroupIndex].remove(key, ns);
   }

--- a/velox/experimental/stateful/state/StreamOperatorStateHandler.h
+++ b/velox/experimental/stateful/state/StreamOperatorStateHandler.h
@@ -80,8 +80,8 @@ class StreamOperatorStateHandler {
     return keyedStateBackend_->getOrCreateRankMapState(stateDescriptor);
   }
 
-  std::shared_ptr<InternalTimerService<uint32_t, int64_t>> createTimerService(
-      Triggerable<uint32_t, int64_t>* triggerable) {
+  std::shared_ptr<InternalTimerService<int64_t, int64_t>> createTimerService(
+      Triggerable<int64_t, int64_t>* triggerable) {
     return keyedStateBackend_->createTimerService(triggerable);
   }
 

--- a/velox/experimental/stateful/window/SliceAssigner.cpp
+++ b/velox/experimental/stateful/window/SliceAssigner.cpp
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 #include "velox/experimental/stateful/window/SliceAssigner.h"
+#include "velox/experimental/stateful/window/Window.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/experimental/stateful/window/TimeWindowUtil.h"
 #include <cstdint>
-
-#include <chrono>
 #include <numeric>
 
 namespace facebook::velox::stateful {
@@ -26,7 +27,7 @@ SliceAssigner::SliceAssigner(
     int64_t size,
     int64_t step,
     int64_t offset,
-    int windowType,
+    WindowType windowType,
     int rowtimeIndex)
     : keySelector_(std::move(keySelector)),
       size_(size),
@@ -38,22 +39,37 @@ SliceAssigner::SliceAssigner(
   sliceSize_ = std::gcd(size, step);
 }
 
-std::map<uint32_t, RowVectorPtr> SliceAssigner::assignSliceEnd(
-    const RowVectorPtr& input) {
+std::map<int64_t, RowVectorPtr> SliceAssigner::assignSliceEnd(const RowVectorPtr& input) {
+  auto calculateWindowEnd = []
+  (WindowType windowType, TypeKind rowtimeFieldType, int64_t timestampMs, int64_t offset, int64_t size) -> int64_t {
+    if (windowType == WindowType::TUMBLE && rowtimeFieldType == TypeKind::TIMESTAMP) {
+      int64_t utcTimestamp = TimeWindowUtil::toEpochMillsForTimer(timestampMs, 0);
+      return stateful::TimeWindowUtil::getWindowStartWithOffset(utcTimestamp, offset, size) + size;
+    } else {
+      return timestampMs;
+    }
+  };
+  TypeKind rowtimeFieldType = input->childAt(rowtimeIndex_)->typeKind();
   if (rowtimeIndex_ < 0) {
-    // TODO: using Processing Time Service
-    auto now = std::chrono::system_clock::now();
-    int64_t timestamp_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            now.time_since_epoch())
-            .count();
-    return {{timestamp_ms, input}};
+    int64_t timestampMs = TimeWindowUtil::getCurrentProcessingTime();
+    return {{calculateWindowEnd(windowType_, rowtimeFieldType, timestampMs, offset_, size_), input}};
+  } else {
+    std::map<int64_t, RowVectorPtr> res;
+    std::map<int64_t, RowVectorPtr> partitionToData = keySelector_->partition(input);
+    for (auto& kv : partitionToData) {
+      int64_t windowEnd = calculateWindowEnd(windowType_, rowtimeFieldType, kv.first, offset_, size_);
+      if (res.count(windowEnd) == 0) {
+        res[windowEnd] = kv.second;
+      } else {
+        res[windowEnd] = TimeWindowUtil::mergeVectors({res[windowEnd], kv.second}, input->pool());
+      }
+    }
+    return res;
   }
-  return keySelector_->partition(input);
 }
 
 int64_t SliceAssigner::getLastWindowEnd(int64_t sliceEnd) {
-  if (windowType_ == 0) { // Hopping window
+  if (windowType_ == WindowType::HOP) { // Hopping window
     return sliceEnd - sliceSize_ + size_;
   }
   return sliceEnd;

--- a/velox/experimental/stateful/window/SliceAssigner.h
+++ b/velox/experimental/stateful/window/SliceAssigner.h
@@ -17,21 +17,22 @@
 #include <cstdint>
 
 #include "velox/experimental/stateful/KeySelector.h"
+#include "velox/experimental/stateful/window/Window.h"
 
 namespace facebook::velox::stateful {
 
 /// This class is relevant to Flink SliceAssigner.
 class SliceAssigner {
- public:
+public:
   SliceAssigner(
-      std::unique_ptr<KeySelector> keySelector,
+      std::unique_ptr<KeySelector>  keySelector,
       int64_t size,
       int64_t step,
       int64_t offset,
-      int windowType,
+      WindowType windowType,
       int rowtimeIndex);
 
-  std::map<uint32_t, RowVectorPtr> assignSliceEnd(const RowVectorPtr& input);
+  std::map<int64_t, RowVectorPtr> assignSliceEnd(const RowVectorPtr& input);
 
   int64_t getLastWindowEnd(int64_t sliceEnd);
 
@@ -41,14 +42,15 @@ class SliceAssigner {
 
   int64_t getSliceEndInterval();
 
- private:
+private:
   const std::unique_ptr<KeySelector> keySelector_;
   const int64_t size_;
   const int64_t step_;
   const int64_t offset_;
-  const int windowType_; // 0: hopping window, 1: slide window
+  const WindowType windowType_;
   int64_t sliceSize_;
   int rowtimeIndex_;
 };
 
 } // namespace facebook::velox::stateful
+ 

--- a/velox/experimental/stateful/window/TimeWindowUtil.cpp
+++ b/velox/experimental/stateful/window/TimeWindowUtil.cpp
@@ -125,4 +125,9 @@ RowVectorPtr TimeWindowUtil::mergeVectors(
   }
   return merged;
 }
+
+int64_t TimeWindowUtil::getCurrentProcessingTime() {
+  auto now = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+}
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/window/TimeWindowUtil.h
+++ b/velox/experimental/stateful/window/TimeWindowUtil.h
@@ -48,6 +48,8 @@ class TimeWindowUtil {
 
   static int64_t
   cleanupTime(int64_t maxTimestamp, int64_t allowedLateness_, bool isEventTime);
+
+  static int64_t getCurrentProcessingTime();
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/window/Window.h
+++ b/velox/experimental/stateful/window/Window.h
@@ -16,10 +16,18 @@
 #pragma once
 #include <cstdint>
 
+#include "velox/common/base/Exceptions.h"
 #include <algorithm>
 #include <string>
 
 namespace facebook::velox::stateful {
+
+enum class WindowType : int {
+  HOP = 0,
+  TUMBLE,
+  SESSION,
+  CUMULATIVE
+};
 
 // This class is relevant to Flink WindowBuffer.
 class Window {
@@ -29,6 +37,14 @@ class Window {
   virtual bool operator<(const Window& other) const = 0;
 
   virtual std::string toString() const = 0;
+
+  static WindowType getType(const int32_t t) {
+    if (t >= 0 && t <= 3) {
+      return static_cast<WindowType>(t);
+    } else {
+      VELOX_FAIL("Window type value {} is illegal, it is not between 0 and 3", t);
+    }
+  }
 };
 
 class TimeWindow : public Window {

--- a/velox/experimental/stateful/window/WindowPartitionFunction.cpp
+++ b/velox/experimental/stateful/window/WindowPartitionFunction.cpp
@@ -16,7 +16,7 @@
 #include "velox/experimental/stateful/window/WindowPartitionFunction.h"
 #include <cstdint>
 #include "velox/experimental/stateful/window/TimeWindowUtil.h"
-#include "velox/vector/FlatVector.h"
+#include "velox/experimental/stateful/window/Window.h"
 
 #include <numeric>
 
@@ -28,21 +28,19 @@ WindowPartitionFunction::WindowPartitionFunction(
     int64_t size,
     int64_t step,
     int64_t offset,
-    int windowType)
+    WindowType windowType)
     : inputType_(std::move(inputType)),
       rowtimeIndex_(rowtimeIndex),
       size_(size),
       step_(step),
       offset_(offset),
       windowType_(windowType) {
-  // VELOX_CHECK_GT(inputType->size(), rowtimeIndex, "rowtimeIndex invalid: {}",
-  //    rowtimeIndex);
   sliceSize_ = std::gcd(size, step);
 }
 
-std::optional<uint32_t> WindowPartitionFunction::partition(
-    const RowVector& input,
-    std::vector<uint32_t>& partitions) {
+std::optional<int64_t> WindowPartitionFunction::partition(
+  const RowVector& input,
+  std::vector<int64_t>& partitions) {
   if (inputType_->childAt(rowtimeIndex_)->kind() == TypeKind::BIGINT) {
     // TODO: this is a optimization, as the RowVector may have be partitioned in
     // local aggregation, so need not to partition again in global agg, but need
@@ -52,24 +50,29 @@ std::optional<uint32_t> WindowPartitionFunction::partition(
     return ts;
   }
   const auto size = input.size();
+  partitions.clear();
   partitions.resize(size);
   // TODO: support more window types. Support time zone.
   for (auto i = 0; i < size; ++i) {
-    auto child = input.childAt(rowtimeIndex_);
+    const auto& child = input.childAt(rowtimeIndex_);
     auto ts = child->as<SimpleVector<Timestamp>>()->valueAt(i);
-    int64_t timestamp = ts.getSeconds() * 1'000 + ts.getNanos() / 1'000'000;
-    if (windowType_ == 0) { // Hopping window
-      int64_t start = TimeWindowUtil::getWindowStartWithOffset(
-          timestamp, offset_, sliceSize_);
+    int64_t timestamp = ts.toMillis();
+    if (windowType_ == WindowType::HOP) { // Hopping window
+      int64_t start = TimeWindowUtil::getWindowStartWithOffset(timestamp, offset_, sliceSize_);
       partitions[i] = start + sliceSize_;
-    } else if (windowType_ == 1) { // Windowed Slice Assigner
+    } else if (windowType_ == WindowType::TUMBLE) { // Windowed Slice Assigner
       partitions[i] = timestamp;
     } else {
-      VELOX_UNSUPPORTED("Unsupported window type: {}", windowType_);
+      VELOX_UNSUPPORTED("Unsupported window type: {}", static_cast<int32_t>(windowType_));
     }
   }
-
   return std::nullopt;
+}
+
+std::optional<uint32_t> WindowPartitionFunction::partition(
+  const RowVector& /* input */,
+  std::vector<uint32_t>& /* partitions */) {
+  VELOX_NYI();
 }
 
 int64_t getTimestamp(
@@ -98,7 +101,7 @@ folly::dynamic StreamWindowPartitionFunctionSpec::serialize() const {
   obj["size"] = size_;
   obj["step"] = step_;
   obj["offset"] = offset_;
-  obj["windowType"] = windowType_;
+  obj["windowType"] = static_cast<int32_t>(windowType_);
   return obj;
 }
 
@@ -110,7 +113,7 @@ core::PartitionFunctionSpecPtr StreamWindowPartitionFunctionSpec::deserialize(
   auto size = obj["size"].asInt();
   auto step = obj["step"].asInt();
   auto offset = obj["offset"].asInt();
-  auto windowType = obj["windowType"].asInt();
+  auto windowType = Window::getType(obj["windowType"].asInt());
 
   return std::make_shared<StreamWindowPartitionFunctionSpec>(
       ISerializable::deserialize<RowType>(obj["inputType"]),

--- a/velox/experimental/stateful/window/WindowPartitionFunction.h
+++ b/velox/experimental/stateful/window/WindowPartitionFunction.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #pragma once
+#include <experimental/stateful/window/Window.h>
 #include <cstdint>
-
 #include "velox/core/PlanNode.h"
 
 namespace facebook::velox::stateful {
@@ -30,11 +30,15 @@ class WindowPartitionFunction : public core::PartitionFunction {
       int64_t size,
       int64_t step,
       int64_t offset,
-      int windowType);
+      WindowType windowType);
 
   std::optional<uint32_t> partition(
       const RowVector& input,
       std::vector<uint32_t>& partitions) override;
+
+  std::optional<int64_t> partition(
+      const RowVector& input,
+      std::vector<int64_t>& partitions) override;
 
  private:
   RowTypePtr inputType_;
@@ -42,7 +46,7 @@ class WindowPartitionFunction : public core::PartitionFunction {
   int64_t size_;
   int64_t step_;
   int64_t offset_;
-  int windowType_;
+  WindowType windowType_;
   int64_t sliceSize_;
 };
 
@@ -54,7 +58,7 @@ class StreamWindowPartitionFunctionSpec : public core::PartitionFunctionSpec {
       int64_t size,
       int64_t step,
       int64_t offset,
-      int windowType)
+      WindowType windowType)
       : inputType_(std::move(inputType)),
         rowtimeIndex_(rowtimeIndex),
         size_(size),
@@ -80,7 +84,7 @@ class StreamWindowPartitionFunctionSpec : public core::PartitionFunctionSpec {
   int64_t size_;
   int64_t step_;
   int64_t offset_;
-  int windowType_;
+  WindowType windowType_;
 };
 
 } // namespace facebook::velox::stateful


### PR DESCRIPTION
支持Timer service功能
1. 支持process timer service： 每条数据对应不同的key 和 timestamp， 对于每个不同的key 和 timestamp，将其注册并保存到对应的queue 中，并定义对应的 SystemProcessTimer，根据定期的系统timer 时间来触发计算；

2.  支持event timer service：同样每条数据对应不同的key 和 timestamp，注册event timer到对应的key中，当watermar assinger 不断的发送watermark 调用advanceWatermark， 将eventTimerQueue中的timer 取出，逐条与watermark，判断是否watermar 是否触发了计算，如果是的话，则计算结果；