### PR TITLE
fix: sync two upstream fixes missing from fork

### DIFF
--- a/velox/external/tzdb/tzdb.h
+++ b/velox/external/tzdb/tzdb.h
@@ -51,7 +51,7 @@ struct tzdb {
     if (const time_zone* __result = __locate_zone(__name))
       return __result;
 
-    std::__throw_runtime_error("tzdb: requested time zone not found");
+    __throw_invalid_time_zone(std::string(__name));
   }
 
   [[nodiscard]] const time_zone* current_zone() const {

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -554,7 +554,7 @@ void FlatVector<T>::resizeValues(
       memcpy(dst, src, len);
     } else {
       const vector_size_t previousSize = BaseVector::length_;
-      auto* rawOldValues = newValues->asMutable<T>();
+      const auto* rawOldValues = values_->as<T>();
       auto* rawNewValues = newValues->asMutable<T>();
       const auto len = std::min<vector_size_t>(newSize, previousSize);
       for (vector_size_t row = 0; row < len; ++row) {


### PR DESCRIPTION
# fix: sync two upstream fixes missing from fork

Two issues already fixed in upstream [facebookincubator/velox](https://github.com/facebookincubator/velox) but missing from this fork.

## Fix 1: tzdb exception type mismatch

**File**: `velox/external/tzdb/tzdb.h:54`
**Upstream**: [facebookincubator/velox/velox/external/tzdb/tzdb.h#L54](https://github.com/facebookincubator/velox/blob/main/velox/external/tzdb/tzdb.h#L54) — already uses `__throw_invalid_time_zone`

`locate_zone()` throws `std::runtime_error`, but velox callers catch `VeloxRuntimeError` (`invalid_time_zone`). The mismatch causes uncaught exceptions and process crash.

**Error Log**:
```
io.github.zhztheplayer.velox4j.exception.VeloxException: tzdb: requested time zone not found
    at io.github.zhztheplayer.velox4j.jni.JniWrapper.queryExecutorExecute(Native Method)
    at io.github.zhztheplayer.velox4j.jni.JniApi.queryExecutorExecute(JniApi.java:84)
    at io.github.zhztheplayer.velox4j.query.QueryExecutor.execute(QueryExecutor.java:37)
```

## Fix 2: FlatVector wrong source buffer in resize

**File**: `velox/vector/FlatVector-inl.h:557`
**Upstream**: [facebookincubator/velox/velox/vector/FlatVector-inl.h#L572](https://github.com/facebookincubator/velox/blob/main/velox/vector/FlatVector-inl.h#L572) — already uses `values_->as<T>()`

`rawOldValues` reads from `newValues` (new buffer) instead of `values_` (old buffer), causing incorrect data copy during non-POD type resize.

## Files Changed

- `velox/external/tzdb/tzdb.h`
- `velox/vector/FlatVector-inl.h`