### PR TITLE
Fix: use lowercased field name in ExtractDateTime comparison

### DIFF
--- a/velox/experimental/stateful/udf/ExtractDateTime.h
+++ b/velox/experimental/stateful/udf/ExtractDateTime.h
@@ -41,21 +41,21 @@ struct ExtractFunction {
     gmtime_r(&time, &timeInfo);
 
     // here to fix compile warning
-    if (field == std::string("year")) {
+    if (fieldLower == "year") {
       result = timeInfo.tm_year + 1900;
-    } else if (field == "month") {
+    } else if (fieldLower == "month") {
       result = timeInfo.tm_mon + 1;
-    } else if (field == "day" || field == "day_of_month") {
+    } else if (fieldLower == "day" || fieldLower == "day_of_month") {
       result = timeInfo.tm_mday;
-    } else if (field == "hour") {
+    } else if (fieldLower == "hour") {
       result = timeInfo.tm_hour;
-    } else if (field == "minute") {
+    } else if (fieldLower == "minute") {
       result = timeInfo.tm_min;
-    } else if (field == "second") {
+    } else if (fieldLower == "second") {
       result = timeInfo.tm_sec;
-    } else if (field == "day_of_week" || field == "dow") {
+    } else if (fieldLower == "day_of_week" || fieldLower == "dow") {
       result = timeInfo.tm_wday == 0 ? 7 : timeInfo.tm_wday;
-    } else if (field == "day_of_year" || field == "doy") {
+    } else if (fieldLower == "day_of_year" || fieldLower == "doy") {
       result = timeInfo.tm_yday + 1;
     } else {
       return false;

--- a/velox/experimental/stateful/udf/tests/UDFTest.cpp
+++ b/velox/experimental/stateful/udf/tests/UDFTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <cstdint>
+#include "velox/core/Expressions.h"
 #include "velox/experimental/stateful/udf/Register.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
@@ -30,7 +31,92 @@ class UDFTest : public functions::test::FunctionBaseTest {
     // stateful::udf::registerFunctions("");
     memory::MemoryManager::testingSetInstance({});
   }
+
+  // Build expression tree directly since 'extract' is a SQL keyword
+  // and cannot be parsed by DuckDB as a function call.
+  core::TypedExprPtr makeExtractExpr(
+      const std::string& field,
+      const TypePtr& timestampType) {
+    return std::make_shared<core::CallTypedExpr>(
+        BIGINT(),
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<core::ConstantTypedExpr>(
+                VARCHAR(), variant(field)),
+            std::make_shared<core::FieldAccessTypedExpr>(timestampType, "c0")},
+        "extract");
+  }
+
+  std::optional<int64_t> extractField(
+      const std::string& field,
+      std::optional<Timestamp> timestamp) {
+    auto rowVector = makeRowVector({
+        makeNullableFlatVector<Timestamp>({timestamp}, TIMESTAMP()),
+    });
+    auto expr = makeExtractExpr(field, TIMESTAMP());
+    auto result = evaluate(expr, rowVector);
+    auto* flatResult = result->asFlatVector<int64_t>();
+    if (flatResult->isNullAt(0)) {
+      return std::nullopt;
+    }
+    return flatResult->valueAt(0);
+  }
 };
+
+// 2026-06-08 09:40:30 UTC (Monday)
+static constexpr int64_t kMondayTs = 1780911630;
+
+// 2026-06-07 00:00:00 UTC (Sunday)
+static constexpr int64_t kSundayTs = 1780790400;
+
+TEST_F(UDFTest, extractAllFields) {
+  auto ts = Timestamp(kMondayTs, 0);
+  stateful::udf::registerFunctions("");
+
+  struct Case {
+    std::string lower;
+    std::string upper;
+    std::string mixed;
+    int64_t expected;
+  };
+
+  const std::vector<Case> fields = {
+      {"year", "YEAR", "Year", 2026},
+      {"month", "MONTH", "Month", 6},
+      {"day", "DAY", "Day", 8},
+      {"day_of_month", "DAY_OF_MONTH", "Day_Of_Month", 8},
+      {"hour", "HOUR", "Hour", 9},
+      {"minute", "MINUTE", "Minute", 40},
+      {"second", "SECOND", "Second", 30},
+      {"day_of_week", "DAY_OF_WEEK", "Day_Of_Week", 1},
+      {"dow", "DOW", "Dow", 1},
+      {"day_of_year", "DAY_OF_YEAR", "Day_Of_Year", 159},
+      {"doy", "DOY", "Doy", 159},
+  };
+
+  for (const auto& f : fields) {
+    EXPECT_EQ(f.expected, extractField(f.lower, ts).value())
+        << "field: " << f.lower;
+    EXPECT_EQ(f.expected, extractField(f.upper, ts).value())
+        << "field: " << f.upper;
+    EXPECT_EQ(f.expected, extractField(f.mixed, ts).value())
+        << "field: " << f.mixed;
+  }
+
+  // Sunday: tm_wday=0 returns 7
+  auto sunday = Timestamp(kSundayTs, 0);
+  for (const auto& name :
+       {"day_of_week", "DAY_OF_WEEK", "Day_Of_Week", "dow", "DOW", "Dow"}) {
+    EXPECT_EQ(7, extractField(name, sunday).value()) << "field: " << name;
+  }
+}
+
+TEST_F(UDFTest, extractUnknownFieldReturnsNull) {
+  auto ts = Timestamp(kMondayTs, 0);
+  stateful::udf::registerFunctions("");
+
+  EXPECT_FALSE(extractField("unknown_field", ts).has_value());
+  EXPECT_FALSE(extractField("UNKNOWN", ts).has_value());
+}
 
 TEST_F(UDFTest, splitIndex) {
   const auto splitIndex = [&](const std::optional<std::string>& a,


### PR DESCRIPTION
## Summary

Fix case-sensitive comparison bug in `ExtractFunction`. The function computes a lowercased copy (`fieldLower`) of the input field name but then compares against the original `field` in all branches. When callers pass uppercase field names (e.g., Flink Calcite sends `"HOUR"` from `TimeUnit.HOUR.toString()`), no branch matches and the function returns `false`, producing NULL results.

## Problem

In nexmark q14, `CASE WHEN HOUR(dateTime) <= 6 ... THEN 'nightTime'` always falls through to ELSE, returning `'otherTime'` for all rows regardless of actual hour value.
related issue: #34 

## Fix

Replace all `field ==` comparisons with `fieldLower ==` (8 occurrences).

## Test

Manual test. Verified with nexmark q14 on Velox-Flink (10000 events, 2533 output rows):

- Before fix: all rows returned `otherTime` (wrong CASE WHEN branch)
- After fix: all rows returned correct `nightTime` matching expected output
- Full field-by-field verification passed
