### PR TITLE
Add native callback bridge for stateful tasks

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -98,7 +98,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// in debugging messages and listings.
   static std::string shortId(const std::string& id);
 
-  ~Task();
+  virtual ~Task();
 
   /// Specify directory to which data will be spilled if spilling is enabled and
   /// required. Set 'alreadyCreated' to true if the directory has already been

--- a/velox/experimental/stateful/NativeCallbackBridge.h
+++ b/velox/experimental/stateful/NativeCallbackBridge.h
@@ -21,7 +21,7 @@ class NativeCallbackBridge {
  public:
   virtual ~NativeCallbackBridge() = default;
 
-  virtual void onProcessElement() = 0;
+  virtual void onProcessingTime(int64_t timestamp) = 0;
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/NativeCallbackBridge.h
+++ b/velox/experimental/stateful/NativeCallbackBridge.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the license at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::velox::stateful {
+
+class NativeCallbackBridge {
+ public:
+  virtual ~NativeCallbackBridge() = default;
+
+  virtual void onProcessElement() = 0;
+};
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/ProcessingTimeTimerService.h
+++ b/velox/experimental/stateful/ProcessingTimeTimerService.h
@@ -152,7 +152,7 @@ class ProcessingTimeTimerService {
           std::make_shared<TimerHeapInternalTimer<K, N>>(std::move(popped)));
     }
   
-    triggerable_->processProcessingTimeByJni(time);
+    triggerable_->onProcessingTime(time);
     if (!taskName.empty()) {
       scheduler_->unregister(taskName);
     }

--- a/velox/experimental/stateful/StatefulOperator.cpp
+++ b/velox/experimental/stateful/StatefulOperator.cpp
@@ -22,6 +22,14 @@ namespace facebook::velox::stateful {
 
 std::shared_ptr<JniCaller> StatefulOperator::jniCaller_;
 
+std::shared_ptr<NativeCallbackBridge> StatefulOperator::nativeCallbackBridge()
+    const {
+  auto task = std::dynamic_pointer_cast<StatefulTask>(
+      operator_->operatorCtx()->task());
+  VELOX_CHECK(task, "Current task is not a StatefulTask");
+  return task->nativeCallbackBridge();
+}
+
 void StatefulOperator::initialize() {
   operator_->initialize();
   for (auto& target : targets_) {

--- a/velox/experimental/stateful/StatefulOperator.h
+++ b/velox/experimental/stateful/StatefulOperator.h
@@ -19,6 +19,7 @@
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/exec/Operator.h"
 #include "velox/experimental/stateful/CombinedWatermarkStatus.h"
+#include "velox/experimental/stateful/NativeCallbackBridge.h"
 #include "velox/experimental/stateful/StreamElement.h"
 #include "velox/experimental/stateful/state/StateBackend.h"
 #include "velox/experimental/stateful/state/StreamOperatorStateHandler.h"
@@ -115,6 +116,8 @@ class StatefulOperator {
   }
 
  protected:
+  std::shared_ptr<NativeCallbackBridge> nativeCallbackBridge() const;
+
   void pushOutput(StreamElementPtr output);
   void emitWatermark(int64_t timestamp);
 

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -16,6 +16,7 @@
 #include "velox/experimental/stateful/StatefulTask.h"
 #include <experimental/stateful/state/StateBackend.h>
 #include <cstdint>
+#include <glog/logging.h>
 #include "velox/exec/OperatorStats.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/experimental/stateful/StatefulPlanner.h"
@@ -152,6 +153,23 @@ StreamElementPtr StatefulTask::next(int32_t& retCode) {
 
 void StatefulTask::addOutput(StreamElementPtr output) {
   pendings_.push_back(std::move(output));
+}
+
+void StatefulTask::setNativeCallbackBridge(
+    std::shared_ptr<NativeCallbackBridge> callbackBridge) {
+  const bool bound = callbackBridge != nullptr;
+  {
+    std::lock_guard<std::mutex> lock(nativeCallbackBridgeMutex_);
+    nativeCallbackBridge_ = std::move(callbackBridge);
+  }
+  LOG(INFO) << (bound ? "Bound" : "Unbound")
+            << " native callback bridge for stateful task: " << taskId();
+}
+
+std::shared_ptr<NativeCallbackBridge> StatefulTask::nativeCallbackBridge()
+    const {
+  std::lock_guard<std::mutex> lock(nativeCallbackBridgeMutex_);
+  return nativeCallbackBridge_;
 }
 
 void StatefulTask::notifyWatermark(int64_t watermark, int index) {

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -159,6 +159,9 @@ void StatefulTask::setNativeCallbackBridge(
     std::shared_ptr<NativeCallbackBridge> callbackBridge) {
   const bool bound = callbackBridge != nullptr;
   {
+    // Protects nativeCallbackBridge_ from concurrent bind/unbind and timer
+    // callbacks. The getter copies the shared_ptr under the same lock so the
+    // bridge stays alive while the callback is being invoked.
     std::lock_guard<std::mutex> lock(nativeCallbackBridgeMutex_);
     nativeCallbackBridge_ = std::move(callbackBridge);
   }

--- a/velox/experimental/stateful/StatefulTask.h
+++ b/velox/experimental/stateful/StatefulTask.h
@@ -15,9 +15,11 @@
  */
 #pragma once
 #include <cstdint>
+#include <mutex>
 
 #include "velox/exec/Task.h"
 #include "velox/exec/TaskStats.h"
+#include "velox/experimental/stateful/NativeCallbackBridge.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
 #include "velox/experimental/stateful/StreamElement.h"
 #include "velox/experimental/stateful/state/StateBackend.h"
@@ -82,6 +84,11 @@ class StatefulTask : public exec::Task {
 
   void addOutput(StreamElementPtr element);
 
+  void setNativeCallbackBridge(
+      std::shared_ptr<NativeCallbackBridge> callbackBridge);
+
+  std::shared_ptr<NativeCallbackBridge> nativeCallbackBridge() const;
+
  private:
   StatefulTask(
       const std::string& taskId,
@@ -106,5 +113,8 @@ class StatefulTask : public exec::Task {
 
   // The state backend used by this task.
   std::unique_ptr<StateBackend> statebackend_;
+
+  mutable std::mutex nativeCallbackBridgeMutex_;
+  std::shared_ptr<NativeCallbackBridge> nativeCallbackBridge_;
 };
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/Triggerable.h
+++ b/velox/experimental/stateful/Triggerable.h
@@ -36,8 +36,7 @@ class Triggerable {
   virtual void onProcessingTime(
       std::shared_ptr<TimerHeapInternalTimer<K, N>> timer) {}
 
-  // For Gluten/Flink, the processing time is triggered by JNI.
-  virtual void processProcessingTimeByJni(int64_t timestamp) {}
+  virtual void onProcessingTime(int64_t timestamp) {}
 
   const std::shared_ptr<std::mutex> getMutex() const {
     return mtx_;

--- a/velox/experimental/stateful/WindowAggregator.cpp
+++ b/velox/experimental/stateful/WindowAggregator.cpp
@@ -281,12 +281,12 @@ void WindowAggregator::onProcessingTime(std::shared_ptr<TimerHeapInternalTimer<i
   onTimer(timer);
 }
 
-void WindowAggregator::processProcessingTimeByJni(int64_t) {
+void WindowAggregator::onProcessingTime(int64_t timestamp) {
   auto callbackBridge = nativeCallbackBridge();
   if (callbackBridge == nullptr) {
     return;
   }
-  callbackBridge->onProcessElement();
+  callbackBridge->onProcessingTime(timestamp);
 }
 
 void WindowAggregator::close() {

--- a/velox/experimental/stateful/WindowAggregator.cpp
+++ b/velox/experimental/stateful/WindowAggregator.cpp
@@ -283,9 +283,9 @@ void WindowAggregator::onProcessingTime(std::shared_ptr<TimerHeapInternalTimer<i
 
 void WindowAggregator::onProcessingTime(int64_t timestamp) {
   auto callbackBridge = nativeCallbackBridge();
-  if (callbackBridge == nullptr) {
-    return;
-  }
+  VELOX_CHECK_NOT_NULL(
+      callbackBridge,
+      "Native callback bridge is not bound for processing-time callback");
   callbackBridge->onProcessingTime(timestamp);
 }
 

--- a/velox/experimental/stateful/WindowAggregator.cpp
+++ b/velox/experimental/stateful/WindowAggregator.cpp
@@ -282,10 +282,11 @@ void WindowAggregator::onProcessingTime(std::shared_ptr<TimerHeapInternalTimer<i
 }
 
 void WindowAggregator::processProcessingTimeByJni(int64_t) {
-  auto& jniCaller = StatefulOperator::jniCaller();
-  VELOX_CHECK(jniCaller, "Jni caller not set");
-  jniCaller->call("org/apache/gluten/streaming/api/operators/GlutenOperator",
-    "processElementByJni", "WindowAggOperator");
+  auto callbackBridge = nativeCallbackBridge();
+  if (callbackBridge == nullptr) {
+    return;
+  }
+  callbackBridge->onProcessElement();
 }
 
 void WindowAggregator::close() {

--- a/velox/experimental/stateful/WindowAggregator.h
+++ b/velox/experimental/stateful/WindowAggregator.h
@@ -71,7 +71,7 @@ class WindowAggregator : public StatefulOperator,
   void onProcessingTime(
       std::shared_ptr<TimerHeapInternalTimer<int64_t, int64_t>> timer) override;
 
-  void processProcessingTimeByJni(int64_t timestamp) override;
+  void onProcessingTime(int64_t timestamp) override;
 
  private:
   void processWatermarkInternal(int64_t timestamp);


### PR DESCRIPTION
## Title
Add native callback bridge for stateful tasks
Description
Adds a native callback bridge for stateful execution so processing-time callbacks can notify the embedding layer directly instead of relying on the previous static JNI caller path.
## Changes
- Added NativeCallbackBridge interface under velox/experimental/stateful.
- Added StatefulTask::setNativeCallbackBridge() and StatefulTask::nativeCallbackBridge().
- Protected callback bridge access with a mutex to avoid races between timer callbacks and bind/unbind lifecycle updates.
- Added bind/unbind logging with stateful task id.
- Updated WindowAggregator::processProcessingTimeByJni() to invoke the native callback bridge.
- Made missing callback bridge a safe no-op for processing-time callbacks.
## Why
WindowAggregator processing-time timers can fire from native scheduler threads. The bridge provides a task-scoped callback target that can be supplied by embedders such as Velox4J/Gluten, avoiding hard-coded Java class/method callback routing.