### PR TITLE
[FLINK]Fix parallelism not consistent in `KafkaSource` and `PrintSink`

### DIFF
--- a/velox/connectors/kafka/KafkaDataSource.cpp
+++ b/velox/connectors/kafka/KafkaDataSource.cpp
@@ -29,7 +29,7 @@ namespace facebook::velox::connector::kafka {
 
 namespace {
 constexpr const char* kTaskIndex = "task_index";
-constexpr const char* kTaskParallelism = "task_parallelism";
+constexpr const char* kTaskParallelism = "parallelism";
 
 uint32_t javaStringHashCode(const std::string& value) {
   uint32_t hash = 0;

--- a/velox/connectors/kafka/tests/KafkaConnectorTestBase.h
+++ b/velox/connectors/kafka/tests/KafkaConnectorTestBase.h
@@ -194,7 +194,7 @@ class KafkaConnectorTestBase : public exec::test::OperatorTestBase {
       int32_t taskParallelism = 1) {
     std::unordered_map<std::string, std::string> sessionConfig;
     sessionConfig["task_index"] = std::to_string(taskIndex);
-    sessionConfig["task_parallelism"] = std::to_string(taskParallelism);
+    sessionConfig["parallelism"] = std::to_string(taskParallelism);
     return createQueryCtxWithSessionProperties(std::move(sessionConfig));
   }
 


### PR DESCRIPTION
In `KafkaSource`, we use `task_parallelism` as parallelism key, in `PrintSink` we use `parallelism` as key, now we make this consistent by using `parallelism` as a final key for task parallelism.