### PR TITLE
feat: Implement idle source handling for WatermarkStatus

### DIFF
--- a/velox/connectors/kafka/KafkaDataSource.cpp
+++ b/velox/connectors/kafka/KafkaDataSource.cpp
@@ -30,6 +30,7 @@ namespace facebook::velox::connector::kafka {
 namespace {
 constexpr const char* kTaskIndex = "task_index";
 constexpr const char* kTaskParallelism = "parallelism";
+constexpr uint32_t kPollTimeoutBackoffMillis = 1;
 
 uint32_t javaStringHashCode(const std::string& value) {
   uint32_t hash = 0;
@@ -58,6 +59,7 @@ KafkaDataSource::KafkaDataSource(
       config_(config),
       outputType_(outputType),
       batchSize_(config_->getDataBatchSize()) {
+  scheduler_.start();
   VELOX_CHECK(batchSize_ > 0, "Batch size config value must greater than 0.");
   const std::shared_ptr<KafkaTableHandle> kafkaTableHandle =
       std::dynamic_pointer_cast<KafkaTableHandle>(tableHandle);
@@ -78,6 +80,11 @@ KafkaDataSource::KafkaDataSource(
   }
   createCachedQueue(batchSize_);
   createRecordDeserializer(config_->getFormat(), outputType_);
+}
+
+KafkaDataSource::~KafkaDataSource() {
+  scheduler_.shutdown();
+  completeBlockingFuture();
 }
 
 bool KafkaDataSource::consumerCanbeCreated() {
@@ -230,9 +237,29 @@ void KafkaDataSource::applyTaskScopedClientId() {
         fmt::format("{}-{}", config_->getClientId(), taskIndex)}});
 }
 
+void KafkaDataSource::completeBlockingFuture() {
+  if (blockingPromise_.has_value()) {
+    blockingPromise_->setValue();
+    blockingPromise_.reset();
+  }
+}
+
+std::optional<RowVectorPtr> KafkaDataSource::blockOnPollTimeout(
+    velox::ContinueFuture& future) {
+  auto [promise, blockedFuture] =
+      makeVeloxContinuePromiseContract("KafkaDataSource::next");
+  blockingPromise_ = std::move(promise);
+  scheduler_.addFunctionOnce(
+      [this]() { completeBlockingFuture(); },
+      fmt::format("KafkaDataSource::next.{}", ++blockingSequence_),
+      std::chrono::milliseconds(kPollTimeoutBackoffMillis));
+  future = std::move(blockedFuture);
+  return std::nullopt;
+}
+
 std::optional<RowVectorPtr> KafkaDataSource::next(
     uint64_t,
-    velox::ContinueFuture&) {
+    velox::ContinueFuture& future) {
   std::optional<RowVectorPtr> res;
   size_t consumedMsgBytes = 0;
   if (queue_.empty()) {
@@ -242,7 +269,7 @@ std::optional<RowVectorPtr> KafkaDataSource::next(
     consumePos_ = 0;
     // If nothing consumed, return directly.
     if (consumedMsgBytes == 0) {
-      return res;
+      return blockOnPollTimeout(future);
     }
   }
   outRow_->prepareForReuse();

--- a/velox/connectors/kafka/KafkaDataSource.h
+++ b/velox/connectors/kafka/KafkaDataSource.h
@@ -16,7 +16,9 @@
 #pragma once
 
 #include <cppkafka/cppkafka.h>
+#include <folly/experimental/FunctionScheduler.h>
 #include <map>
+#include <optional>
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/connectors/Connector.h"
@@ -41,6 +43,8 @@ class KafkaDataSource : public DataSource {
       const TableHandlePtr& tableHandle,
       const ConnectorQueryCtx* connectorQueryCtx,
       const ConnectionConfigPtr& connectionConfig);
+
+  ~KafkaDataSource() override;
 
   /// Create a kafka connection to the given topics and partitions.
   void addSplit(ConnectorSplitPtr split) override;
@@ -98,6 +102,9 @@ class KafkaDataSource : public DataSource {
   KafkaConsumerPtr consumer_;
   /// The kafka record deserializer.
   KafkaRecordDeserializerPtr deserializer_;
+  folly::FunctionScheduler scheduler_;
+  std::optional<ContinuePromise> blockingPromise_;
+  uint64_t blockingSequence_{0};
   /// Count how many rows consumed.
   uint64_t completedRows_ = 0;
   /// Count how many bytes consumed.
@@ -151,6 +158,10 @@ class KafkaDataSource : public DataSource {
   void applyTaskScopedClientId();
 
   void applyRestoredOffsets(cppkafka::TopicPartitionList& topicPartitions);
+
+  void completeBlockingFuture();
+
+  std::optional<RowVectorPtr> blockOnPollTimeout(velox::ContinueFuture& future);
 
   bool hasOffsetsToCommit(const TopicPartitionOffsets& offsets) const;
 

--- a/velox/experimental/stateful/CMakeLists.txt
+++ b/velox/experimental/stateful/CMakeLists.txt
@@ -38,7 +38,8 @@ velox_add_library(
   WatermarkGenerator.cpp
   WatermarkSource.cpp
   WatermarkAssigner.cpp
-  StreamRecordTimestampInserter.cpp)
+  StreamRecordTimestampInserter.cpp
+  WatermarkIdleTracker.cpp)
 
 velox_link_libraries(
   velox_stateful_exec

--- a/velox/experimental/stateful/IdleTimerManager.h
+++ b/velox/experimental/stateful/IdleTimerManager.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "velox/experimental/stateful/ProcessingTimeScheduler.h"
+
+namespace facebook::velox::stateful {
+
+// Shared one-shot idle timer helper for watermark-generating operators. It
+// owns the background scheduler, prevents duplicate timer registrations, skips
+// scheduling after the owner is already idle, and clamps past idle deadlines to
+// the current time.
+class IdleTimerManager {
+ public:
+  using TimerCallback = std::function<void(int64_t)>;
+
+  ~IdleTimerManager() {
+    shutdown();
+  }
+
+  void schedule(
+      int64_t now,
+      bool enabled,
+      bool idle,
+      int64_t idleDeadline,
+      TimerCallback callback) {
+    if (!enabled || idle || timerPending_.exchange(true)) {
+      return;
+    }
+    if (!scheduler_) {
+      scheduler_ = std::make_unique<SystemProcessingTimeScheduler>();
+    }
+    const int64_t fireAt = idleDeadline < now ? now : idleDeadline;
+    scheduler_->registerTimer(
+        fireAt,
+        ProcessingTimerTask(
+            fireAt,
+            [this, callback = std::move(callback)](int64_t timestamp) mutable {
+              timerPending_ = false;
+              callback(timestamp);
+            }));
+  }
+
+  void shutdown() {
+    if (scheduler_) {
+      scheduler_->close();
+      scheduler_.reset();
+    }
+    timerPending_ = false;
+  }
+
+ private:
+  std::unique_ptr<ProcessingTimeScheduler> scheduler_;
+  std::atomic<bool> timerPending_{false};
+};
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/IdleTimerManager.h
+++ b/velox/experimental/stateful/IdleTimerManager.h
@@ -33,6 +33,10 @@ class IdleTimerManager {
  public:
   using TimerCallback = std::function<void(int64_t)>;
 
+  explicit IdleTimerManager(
+      std::unique_ptr<ProcessingTimeScheduler> scheduler = nullptr)
+      : scheduler_(std::move(scheduler)) {}
+
   ~IdleTimerManager() {
     shutdown();
   }

--- a/velox/experimental/stateful/StatefulOperator.cpp
+++ b/velox/experimental/stateful/StatefulOperator.cpp
@@ -27,7 +27,9 @@ std::shared_ptr<NativeCallbackBridge> StatefulOperator::nativeCallbackBridge()
     const {
   auto task =
       std::dynamic_pointer_cast<StatefulTask>(operator_->operatorCtx()->task());
-  VELOX_CHECK(task, "Current task is not a StatefulTask");
+  if (!task) {
+    return nullptr;
+  }
   return task->nativeCallbackBridge();
 }
 

--- a/velox/experimental/stateful/StatefulOperator.cpp
+++ b/velox/experimental/stateful/StatefulOperator.cpp
@@ -210,6 +210,12 @@ void StatefulOperator::processWatermarkStatus(bool idle) {
   processWatermarkStatus(idle, 0);
 }
 
+void StatefulOperator::checkWatermarkStatus(int64_t now) {
+  for (auto& target : targets_) {
+    target->checkWatermarkStatus(now);
+  }
+}
+
 void StatefulOperator::initializeStateBackend(StateBackend* stateBackend) {
   if (!stateHandler_) {
     stateHandler_ = std::make_shared<StreamOperatorStateHandler>(

--- a/velox/experimental/stateful/StatefulOperator.h
+++ b/velox/experimental/stateful/StatefulOperator.h
@@ -46,9 +46,11 @@ class StatefulOperator {
           keyedStateBackendParameters = nullptr)
       : keyedStateBackendParameters_(keyedStateBackendParameters),
         operator_(std::move(op)),
-        targets_(std::move(targets)) {
+         targets_(std::move(targets)) {
     sink = operator_->operatorType() == "TableWrite";
   }
+
+  virtual ~StatefulOperator() = default;
 
   virtual void initialize();
 
@@ -73,6 +75,13 @@ class StatefulOperator {
   virtual void processWatermarkStatus(bool idle, int32_t index);
 
   virtual void processWatermarkStatus(bool idle);
+
+  /// Called periodically by the driver thread (via StatefulTask::next) after
+  /// each drain attempt. Operators with idle-timeout detection (e.g.
+  /// WatermarkAssigner) override this to check for input idleness and emit
+  /// WatermarkStatus events into the task output. The default implementation
+  /// recursively forwards the call to downstream targets.
+  virtual void checkWatermarkStatus(int64_t now);
 
   virtual void initializeState();
 

--- a/velox/experimental/stateful/StatefulOperator.h
+++ b/velox/experimental/stateful/StatefulOperator.h
@@ -46,7 +46,7 @@ class StatefulOperator {
           keyedStateBackendParameters = nullptr)
       : keyedStateBackendParameters_(keyedStateBackendParameters),
         operator_(std::move(op)),
-         targets_(std::move(targets)) {
+        targets_(std::move(targets)) {
     sink = operator_->operatorType() == "TableWrite";
   }
 

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -22,6 +22,7 @@
 #include "velox/experimental/stateful/StatefulPlanner.h"
 #include "velox/experimental/stateful/state/HashMapStateBackend.h"
 #include "velox/experimental/stateful/state/RocksDBStateBackend.h"
+#include "velox/experimental/stateful/window/TimeWindowUtil.h"
 
 namespace facebook::velox::stateful {
 
@@ -141,21 +142,28 @@ StreamElementPtr StatefulTask::next(ContinueFuture* future, int32_t& retCode) {
 
   operatorChain_->advanceWithFuture(future);
   if (future != nullptr && future->valid()) {
+    // Source is blocked. Give operators a chance to detect idle input and
+    // emit WatermarkStatus events into pendings_ before returning.
+    checkWatermarkStatus(TimeWindowUtil::getCurrentProcessingTime());
     return nullptr;
   }
   if (pendings_.empty()) {
-    if (operatorChain_->isFinished()) {
-      operatorChain_->finish();
-      finish();
-      // finish may trigger window flush and generate output.
-      if (pendings_.empty()) {
-        retCode = 1;
+    // No output produced. Give operators a chance to detect idle input.
+    checkWatermarkStatus(TimeWindowUtil::getCurrentProcessingTime());
+    if (pendings_.empty()) {
+      if (operatorChain_->isFinished()) {
+        operatorChain_->finish();
+        finish();
+        // finish may trigger window flush and generate output.
+        if (pendings_.empty()) {
+          retCode = 1;
+          return nullptr;
+        }
+      } else if (operatorChain_->sourceEmpty()) {
+        return nullptr;
+      } else {
         return nullptr;
       }
-    } else if (operatorChain_->sourceEmpty()) {
-      return nullptr;
-    } else {
-      return nullptr;
     }
   }
   return popOutput();
@@ -199,6 +207,12 @@ void StatefulTask::notifyWatermarkStatus(bool idle, int32_t index) {
 
 void StatefulTask::notifyWatermarkStatus(bool idle) {
   operatorChain_->processWatermarkStatus(idle);
+}
+
+void StatefulTask::checkWatermarkStatus(int64_t now) {
+  if (operatorChain_) {
+    operatorChain_->checkWatermarkStatus(now);
+  }
 }
 
 void StatefulTask::initializeState(

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -145,24 +145,27 @@ StreamElementPtr StatefulTask::next(ContinueFuture* future, int32_t& retCode) {
     // Source is blocked. Give operators a chance to detect idle input and
     // emit WatermarkStatus events into pendings_ before returning.
     checkWatermarkStatus(TimeWindowUtil::getCurrentProcessingTime());
-    return nullptr;
-  }
-  if (pendings_.empty()) {
-    // No output produced. Give operators a chance to detect idle input.
-    checkWatermarkStatus(TimeWindowUtil::getCurrentProcessingTime());
     if (pendings_.empty()) {
-      if (operatorChain_->isFinished()) {
-        operatorChain_->finish();
-        finish();
-        // finish may trigger window flush and generate output.
-        if (pendings_.empty()) {
-          retCode = 1;
+      return nullptr;
+    }
+  } else {
+    if (pendings_.empty()) {
+      // No output produced. Give operators a chance to detect idle input.
+      checkWatermarkStatus(TimeWindowUtil::getCurrentProcessingTime());
+      if (pendings_.empty()) {
+        if (operatorChain_->isFinished()) {
+          operatorChain_->finish();
+          finish();
+          // finish may trigger window flush and generate output.
+          if (pendings_.empty()) {
+            retCode = 1;
+            return nullptr;
+          }
+        } else if (operatorChain_->sourceEmpty()) {
+          return nullptr;
+        } else {
           return nullptr;
         }
-      } else if (operatorChain_->sourceEmpty()) {
-        return nullptr;
-      } else {
-        return nullptr;
       }
     }
   }

--- a/velox/experimental/stateful/StatefulTask.h
+++ b/velox/experimental/stateful/StatefulTask.h
@@ -72,6 +72,10 @@ class StatefulTask : public exec::Task {
 
   void notifyWatermarkStatus(bool idle);
 
+  /// Called on the driver thread to give each operator in the chain a chance
+  /// to perform idle-timeout detection and emit WatermarkStatus events.
+  void checkWatermarkStatus(int64_t now);
+
   void initializeState(
       const std::shared_ptr<const KeyedStateBackendParameters> params,
       const std::vector<std::string>& checkpointRecords = {});

--- a/velox/experimental/stateful/WatermarkAssigner.cpp
+++ b/velox/experimental/stateful/WatermarkAssigner.cpp
@@ -16,6 +16,7 @@
 #include "velox/experimental/stateful/WatermarkAssigner.h"
 
 #include "velox/experimental/stateful/WatermarkGenerator.h"
+#include "velox/experimental/stateful/window/TimeWindowUtil.h"
 
 namespace facebook::velox::stateful {
 
@@ -28,12 +29,26 @@ WatermarkAssigner::WatermarkAssigner(
     : StatefulOperator(std::move(op), std::move(targets)),
       idleTimeout_(idleTimeout),
       rowtimeFieldIndex_(rowtimeFieldIndex),
-      watermarkInterval_(watermarkInterval) {}
+      watermarkInterval_(watermarkInterval),
+      idleTracker_(idleTimeout) {}
+
+WatermarkAssigner::~WatermarkAssigner() {
+  WatermarkAssigner::close();
+}
 
 void WatermarkAssigner::addInput(StreamElementPtr input) {
   auto record = std::static_pointer_cast<StreamRecord>(input);
   input_ = record->record();
   op()->addInput(input_);
+
+  if (idleTracker_.isEnabled()) {
+    int64_t now = TimeWindowUtil::getCurrentProcessingTime();
+    if (idleTracker_.onRecord(now)) {
+      // Was idle; emit WatermarkStatus.ACTIVE downstream.
+      emitWatermarkStatus(false);
+    }
+    scheduleIdleTimer(now);
+  }
 }
 
 void WatermarkAssigner::advance() {
@@ -78,7 +93,54 @@ void WatermarkAssigner::advance() {
   input_.reset();
 }
 
+void WatermarkAssigner::checkWatermarkStatus(int64_t now) {
+  if (!idleTracker_.isEnabled()) {
+    StatefulOperator::checkWatermarkStatus(now);
+    return;
+  }
+
+  if (idleCheckRequested_.exchange(false)) {
+    if (idleTracker_.checkIdle(now)) {
+      emitWatermarkStatus(true);
+    }
+    // Reschedule the next idle check.
+    scheduleIdleTimer(now);
+  }
+
+  // Forward to downstream targets.
+  StatefulOperator::checkWatermarkStatus(now);
+}
+
+void WatermarkAssigner::scheduleIdleTimer(int64_t now) {
+  if (!idleTracker_.isEnabled()) {
+    return;
+  }
+  if (!scheduler_) {
+    scheduler_ = std::make_unique<SystemProcessingTimeScheduler>();
+  }
+  int64_t fireAt = now + idleTimeout_;
+  scheduler_->registerTimer(
+      fireAt, ProcessingTimerTask(fireAt, [this](int64_t timestamp) {
+        onIdleTimerFired(timestamp);
+      }));
+}
+
+void WatermarkAssigner::onIdleTimerFired(int64_t timestamp) {
+  // Runs on the background scheduler thread. Signal the driver thread to
+  // perform the idle check and wake the Java mailbox so it can drain any
+  // emitted WatermarkStatus event from pendings_.
+  idleCheckRequested_.store(true);
+  auto bridge = nativeCallbackBridge();
+  if (bridge) {
+    bridge->onProcessingTime(timestamp);
+  }
+}
+
 void WatermarkAssigner::close() {
+  if (scheduler_) {
+    scheduler_->close();
+    scheduler_.reset();
+  }
   StatefulOperator::close();
   input_.reset();
 }

--- a/velox/experimental/stateful/WatermarkAssigner.cpp
+++ b/velox/experimental/stateful/WatermarkAssigner.cpp
@@ -98,10 +98,8 @@ void WatermarkAssigner::checkWatermarkStatus(int64_t now) {
     return;
   }
 
-  if (idleCheckRequested_.exchange(false)) {
-    if (idleTracker_.checkIdle(now)) {
-      emitWatermarkStatus(true);
-    }
+  if (idleTracker_.checkIdle(now)) {
+    emitWatermarkStatus(true);
   }
 
   scheduleIdleTimer(now);
@@ -125,10 +123,7 @@ void WatermarkAssigner::scheduleIdleTimer(int64_t now) {
 }
 
 void WatermarkAssigner::onIdleTimerFired(int64_t timestamp) {
-  // Clear pending flag before signalling so checkWatermarkStatus can
-  // re-register the next timer.
   timerPending_ = false;
-  idleCheckRequested_.store(true);
   auto bridge = nativeCallbackBridge();
   if (bridge) {
     bridge->onProcessingTime(timestamp);

--- a/velox/experimental/stateful/WatermarkAssigner.cpp
+++ b/velox/experimental/stateful/WatermarkAssigner.cpp
@@ -47,7 +47,6 @@ void WatermarkAssigner::addInput(StreamElementPtr input) {
       // Was idle; emit WatermarkStatus.ACTIVE downstream.
       emitWatermarkStatus(false);
     }
-    scheduleIdleTimer(now);
   }
 }
 
@@ -103,16 +102,16 @@ void WatermarkAssigner::checkWatermarkStatus(int64_t now) {
     if (idleTracker_.checkIdle(now)) {
       emitWatermarkStatus(true);
     }
-    // Reschedule the next idle check.
-    scheduleIdleTimer(now);
   }
+
+  scheduleIdleTimer(now);
 
   // Forward to downstream targets.
   StatefulOperator::checkWatermarkStatus(now);
 }
 
 void WatermarkAssigner::scheduleIdleTimer(int64_t now) {
-  if (!idleTracker_.isEnabled()) {
+  if (!idleTracker_.isEnabled() || timerPending_.exchange(true)) {
     return;
   }
   if (!scheduler_) {
@@ -126,9 +125,9 @@ void WatermarkAssigner::scheduleIdleTimer(int64_t now) {
 }
 
 void WatermarkAssigner::onIdleTimerFired(int64_t timestamp) {
-  // Runs on the background scheduler thread. Signal the driver thread to
-  // perform the idle check and wake the Java mailbox so it can drain any
-  // emitted WatermarkStatus event from pendings_.
+  // Clear pending flag before signalling so checkWatermarkStatus can
+  // re-register the next timer.
+  timerPending_ = false;
   idleCheckRequested_.store(true);
   auto bridge = nativeCallbackBridge();
   if (bridge) {

--- a/velox/experimental/stateful/WatermarkAssigner.cpp
+++ b/velox/experimental/stateful/WatermarkAssigner.cpp
@@ -32,7 +32,7 @@ WatermarkAssigner::WatermarkAssigner(
       idleTracker_(idleTimeout) {}
 
 WatermarkAssigner::~WatermarkAssigner() {
-  WatermarkAssigner::close();
+  shutdownScheduler();
 }
 
 void WatermarkAssigner::addInput(StreamElementPtr input) {
@@ -121,8 +121,12 @@ void WatermarkAssigner::scheduleIdleTimer(int64_t now) {
       });
 }
 
-void WatermarkAssigner::close() {
+void WatermarkAssigner::shutdownScheduler() {
   idleTimerManager_.shutdown();
+}
+
+void WatermarkAssigner::close() {
+  shutdownScheduler();
   StatefulOperator::close();
   input_.reset();
 }

--- a/velox/experimental/stateful/WatermarkAssigner.cpp
+++ b/velox/experimental/stateful/WatermarkAssigner.cpp
@@ -27,7 +27,6 @@ WatermarkAssigner::WatermarkAssigner(
     const int rowtimeFieldIndex,
     const int64_t watermarkInterval)
     : StatefulOperator(std::move(op), std::move(targets)),
-      idleTimeout_(idleTimeout),
       rowtimeFieldIndex_(rowtimeFieldIndex),
       watermarkInterval_(watermarkInterval),
       idleTracker_(idleTimeout) {}
@@ -109,32 +108,21 @@ void WatermarkAssigner::checkWatermarkStatus(int64_t now) {
 }
 
 void WatermarkAssigner::scheduleIdleTimer(int64_t now) {
-  if (!idleTracker_.isEnabled() || timerPending_.exchange(true)) {
-    return;
-  }
-  if (!scheduler_) {
-    scheduler_ = std::make_unique<SystemProcessingTimeScheduler>();
-  }
-  int64_t fireAt = now + idleTimeout_;
-  scheduler_->registerTimer(
-      fireAt, ProcessingTimerTask(fireAt, [this](int64_t timestamp) {
-        onIdleTimerFired(timestamp);
-      }));
-}
-
-void WatermarkAssigner::onIdleTimerFired(int64_t timestamp) {
-  timerPending_ = false;
-  auto bridge = nativeCallbackBridge();
-  if (bridge) {
-    bridge->onProcessingTime(timestamp);
-  }
+  idleTimerManager_.schedule(
+      now,
+      idleTracker_.isEnabled(),
+      idleTracker_.isIdle(),
+      idleTracker_.idleDeadline(),
+      [this](int64_t timestamp) {
+        auto bridge = nativeCallbackBridge();
+        if (bridge) {
+          bridge->onProcessingTime(timestamp);
+        }
+      });
 }
 
 void WatermarkAssigner::close() {
-  if (scheduler_) {
-    scheduler_->close();
-    scheduler_.reset();
-  }
+  idleTimerManager_.shutdown();
   StatefulOperator::close();
   input_.reset();
 }

--- a/velox/experimental/stateful/WatermarkAssigner.h
+++ b/velox/experimental/stateful/WatermarkAssigner.h
@@ -82,12 +82,9 @@ class WatermarkAssigner : public StatefulOperator {
   // first record arrival if idleness detection is enabled.
   std::unique_ptr<ProcessingTimeScheduler> scheduler_;
 
-  // Set by the background timer thread to request an idle check on the driver
-  // thread; drained by checkWatermarkStatus().
-  std::atomic<bool> idleCheckRequested_{false};
-
   // Set to true when a timer is registered, cleared when it fires. Prevents
-  // duplicate timer registrations.
+  // duplicate timer registrations. The true→false transition also signals
+  // checkWatermarkStatus to perform an idle check.
   std::atomic<bool> timerPending_{false};
 };
 

--- a/velox/experimental/stateful/WatermarkAssigner.h
+++ b/velox/experimental/stateful/WatermarkAssigner.h
@@ -85,6 +85,10 @@ class WatermarkAssigner : public StatefulOperator {
   // Set by the background timer thread to request an idle check on the driver
   // thread; drained by checkWatermarkStatus().
   std::atomic<bool> idleCheckRequested_{false};
+
+  // Set to true when a timer is registered, cleared when it fires. Prevents
+  // duplicate timer registrations.
+  std::atomic<bool> timerPending_{false};
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkAssigner.h
+++ b/velox/experimental/stateful/WatermarkAssigner.h
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 #pragma once
-#include <atomic>
 #include <cstdint>
 #include <memory>
 
-#include "velox/experimental/stateful/ProcessingTimeScheduler.h"
+#include "velox/experimental/stateful/IdleTimerManager.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
 #include "velox/experimental/stateful/StreamElement.h"
 #include "velox/experimental/stateful/WatermarkIdleTracker.h"
@@ -58,18 +57,13 @@ class WatermarkAssigner : public StatefulOperator {
   }
 
  private:
-  /// Schedules (or reschedules) the one-shot idle-detection timer on the
-  /// background processing-time scheduler. When the timer fires it sets the
-  /// idleCheckRequested_ flag and wakes the Java mailbox via the native
-  /// callback bridge so the driver thread can drain any emitted
+  /// Schedules a one-shot idle-detection timer on the background
+  /// processing-time scheduler. When the timer fires it wakes the Java mailbox
+  /// via the native callback bridge so the driver thread can drain any emitted
   /// WatermarkStatus event.
   void scheduleIdleTimer(int64_t now);
 
-  /// Invoked from the background scheduler thread.
-  void onIdleTimerFired(int64_t timestamp);
-
   RowVectorPtr input_;
-  const int64_t idleTimeout_;
   const int rowtimeFieldIndex_;
   const int64_t watermarkInterval_;
 
@@ -77,14 +71,7 @@ class WatermarkAssigner : public StatefulOperator {
   int64_t lastWatermark = 0;
 
   WatermarkIdleTracker idleTracker_;
-
-  // Background scheduler for idle-detection timers. Lazily created on the
-  // first record arrival if idleness detection is enabled.
-  std::unique_ptr<ProcessingTimeScheduler> scheduler_;
-
-  // Set to true when a timer is registered, cleared when it fires. Prevents
-  // duplicate timer registrations.
-  std::atomic<bool> timerPending_{false};
+  IdleTimerManager idleTimerManager_;
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkAssigner.h
+++ b/velox/experimental/stateful/WatermarkAssigner.h
@@ -14,17 +14,23 @@
  * limitations under the License.
  */
 #pragma once
+#include <atomic>
 #include <cstdint>
+#include <memory>
 
+#include "velox/experimental/stateful/ProcessingTimeScheduler.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
 #include "velox/experimental/stateful/StreamElement.h"
+#include "velox/experimental/stateful/WatermarkIdleTracker.h"
 
 namespace facebook::velox::stateful {
 
 /// It is related to
 /// org.apache.flink.table.runtime.operators.wmassigners.WatermarkAssignerOperator
 /// in Flink. It extracts timestamp from each row and generates periodic
-/// watermark.
+/// watermark. When an idle timeout is configured, it also detects idle input
+/// and emits WatermarkStatus.IDLE / ACTIVE downstream, mirroring Flink's
+/// WatermarkAssignerOperator idleness semantics.
 class WatermarkAssigner : public StatefulOperator {
  public:
   WatermarkAssigner(
@@ -34,17 +40,34 @@ class WatermarkAssigner : public StatefulOperator {
       const int rowtimeFieldIndex,
       const int64_t watermarkInterval);
 
+  ~WatermarkAssigner() override;
+
   void addInput(StreamElementPtr input) override;
 
   void advance() override;
+
+  void close() override;
+
+  /// Invoked by the driver thread (via StatefulTask::next) after each drain
+  /// attempt. Performs the idle check and emits WatermarkStatus if the input
+  /// has just transitioned to idle.
+  void checkWatermarkStatus(int64_t now) override;
 
   std::string name() const override {
     return "WatermarkAssigner";
   }
 
-  void close() override;
-
  private:
+  /// Schedules (or reschedules) the one-shot idle-detection timer on the
+  /// background processing-time scheduler. When the timer fires it sets the
+  /// idleCheckRequested_ flag and wakes the Java mailbox via the native
+  /// callback bridge so the driver thread can drain any emitted
+  /// WatermarkStatus event.
+  void scheduleIdleTimer(int64_t now);
+
+  /// Invoked from the background scheduler thread.
+  void onIdleTimerFired(int64_t timestamp);
+
   RowVectorPtr input_;
   const int64_t idleTimeout_;
   const int rowtimeFieldIndex_;
@@ -52,5 +75,16 @@ class WatermarkAssigner : public StatefulOperator {
 
   int64_t currentWatermark = 0;
   int64_t lastWatermark = 0;
+
+  WatermarkIdleTracker idleTracker_;
+
+  // Background scheduler for idle-detection timers. Lazily created on the
+  // first record arrival if idleness detection is enabled.
+  std::unique_ptr<ProcessingTimeScheduler> scheduler_;
+
+  // Set by the background timer thread to request an idle check on the driver
+  // thread; drained by checkWatermarkStatus().
+  std::atomic<bool> idleCheckRequested_{false};
 };
+
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkAssigner.h
+++ b/velox/experimental/stateful/WatermarkAssigner.h
@@ -83,8 +83,7 @@ class WatermarkAssigner : public StatefulOperator {
   std::unique_ptr<ProcessingTimeScheduler> scheduler_;
 
   // Set to true when a timer is registered, cleared when it fires. Prevents
-  // duplicate timer registrations. The true→false transition also signals
-  // checkWatermarkStatus to perform an idle check.
+  // duplicate timer registrations.
   std::atomic<bool> timerPending_{false};
 };
 

--- a/velox/experimental/stateful/WatermarkAssigner.h
+++ b/velox/experimental/stateful/WatermarkAssigner.h
@@ -63,6 +63,8 @@ class WatermarkAssigner : public StatefulOperator {
   /// WatermarkStatus event.
   void scheduleIdleTimer(int64_t now);
 
+  void shutdownScheduler();
+
   RowVectorPtr input_;
   const int rowtimeFieldIndex_;
   const int64_t watermarkInterval_;

--- a/velox/experimental/stateful/WatermarkGenerator.cpp
+++ b/velox/experimental/stateful/WatermarkGenerator.cpp
@@ -108,7 +108,8 @@ WatermarkGenerator::WatermarkGenerator(
     : op_(std::move(op)),
       idleTimeout_(idleTimeout),
       rowtimeFieldIndex_(rowtimeFieldIndex),
-      watermarkInterval_(watermarkInterval) {}
+      watermarkInterval_(watermarkInterval),
+      idleTracker_(idleTimeout) {}
 
 std::optional<int64_t> WatermarkGenerator::generate(const RowVectorPtr& input) {
   watermark::validateRowtimeNoNulls(input, rowtimeFieldIndex_);

--- a/velox/experimental/stateful/WatermarkGenerator.h
+++ b/velox/experimental/stateful/WatermarkGenerator.h
@@ -95,6 +95,10 @@ class WatermarkGenerator {
     return idleTracker_.isIdle();
   }
 
+  int64_t idleDeadline() const {
+    return idleTracker_.idleDeadline();
+  }
+
   bool isIdlenessEnabled() const {
     return idleTracker_.isEnabled();
   }

--- a/velox/experimental/stateful/WatermarkGenerator.h
+++ b/velox/experimental/stateful/WatermarkGenerator.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "velox/exec/Operator.h"
+#include "velox/experimental/stateful/WatermarkIdleTracker.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::stateful {
@@ -77,18 +78,42 @@ class WatermarkGenerator {
     return lastWatermark_;
   }
 
+  /// Notifies the tracker that input data has arrived. Returns true if the
+  /// tracker was previously idle (caller should emit WatermarkStatus.ACTIVE).
+  bool onRecord(int64_t now) {
+    return idleTracker_.onRecord(now);
+  }
+
+  /// Checks whether the input has been idle long enough to transition to IDLE.
+  /// Returns true if the tracker just became idle (caller should emit
+  /// WatermarkStatus.IDLE).
+  bool checkIdle(int64_t now) {
+    return idleTracker_.checkIdle(now);
+  }
+
+  bool isIdle() const {
+    return idleTracker_.isIdle();
+  }
+
+  bool isIdlenessEnabled() const {
+    return idleTracker_.isEnabled();
+  }
+
+  int64_t idleTimeout() const {
+    return idleTimeout_;
+  }
+
   void initialize() {
     op_->initialize();
   }
 
  private:
   std::unique_ptr<exec::Operator> op_;
-  // TODO: Use idleTimeout_ to detect idle inputs and emit idle/active watermark
-  // status, matching Flink WatermarkAssignerOperator semantics.
   const int64_t idleTimeout_;
   const int rowtimeFieldIndex_;
   const int64_t watermarkInterval_;
   int64_t currentWatermark_ = 0;
   int64_t lastWatermark_ = 0;
+  WatermarkIdleTracker idleTracker_;
 };
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkIdleTracker.cpp
+++ b/velox/experimental/stateful/WatermarkIdleTracker.cpp
@@ -25,6 +25,7 @@ bool WatermarkIdleTracker::onRecord(int64_t currentWallMs) {
     return false;
   }
   lastRecordWallTime_ = currentWallMs;
+  baselineInitialized_ = true;
   if (idle_) {
     idle_ = false;
     return true;
@@ -36,10 +37,11 @@ bool WatermarkIdleTracker::checkIdle(int64_t currentWallMs) {
   if (!isEnabled() || idle_) {
     return false;
   }
-  if (lastRecordWallTime_ == 0) {
+  if (!baselineInitialized_) {
     // No record has ever arrived. Treat the first check as the baseline so we
     // do not immediately declare idleness before any data has been seen.
     lastRecordWallTime_ = currentWallMs;
+    baselineInitialized_ = true;
     return false;
   }
   if (currentWallMs - lastRecordWallTime_ > idleTimeout_) {

--- a/velox/experimental/stateful/WatermarkIdleTracker.cpp
+++ b/velox/experimental/stateful/WatermarkIdleTracker.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/stateful/WatermarkIdleTracker.h"
+
+namespace facebook::velox::stateful {
+
+WatermarkIdleTracker::WatermarkIdleTracker(int64_t idleTimeoutMs)
+    : idleTimeout_(idleTimeoutMs) {}
+
+bool WatermarkIdleTracker::onRecord(int64_t currentWallMs) {
+  if (!isEnabled()) {
+    return false;
+  }
+  lastRecordWallTime_ = currentWallMs;
+  if (idle_) {
+    idle_ = false;
+    return true;
+  }
+  return false;
+}
+
+bool WatermarkIdleTracker::checkIdle(int64_t currentWallMs) {
+  if (!isEnabled() || idle_) {
+    return false;
+  }
+  if (lastRecordWallTime_ == 0) {
+    // No record has ever arrived. Treat the first check as the baseline so we
+    // do not immediately declare idleness before any data has been seen.
+    lastRecordWallTime_ = currentWallMs;
+    return false;
+  }
+  if (currentWallMs - lastRecordWallTime_ > idleTimeout_) {
+    idle_ = true;
+    return true;
+  }
+  return false;
+}
+
+bool WatermarkIdleTracker::isIdle() const {
+  return idle_;
+}
+
+bool WatermarkIdleTracker::isEnabled() const {
+  return idleTimeout_ > 0;
+}
+
+void WatermarkIdleTracker::setIdle(bool idle) {
+  idle_ = idle;
+}
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkIdleTracker.cpp
+++ b/velox/experimental/stateful/WatermarkIdleTracker.cpp
@@ -59,6 +59,10 @@ bool WatermarkIdleTracker::isEnabled() const {
   return idleTimeout_ > 0;
 }
 
+int64_t WatermarkIdleTracker::idleDeadline() const {
+  return lastRecordWallTime_ + idleTimeout_;
+}
+
 void WatermarkIdleTracker::setIdle(bool idle) {
   idle_ = idle;
 }

--- a/velox/experimental/stateful/WatermarkIdleTracker.h
+++ b/velox/experimental/stateful/WatermarkIdleTracker.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <cstdint>
+
+namespace facebook::velox::stateful {
+
+/// Tracks input idleness for a watermark-generating operator
+/// (WatermarkAssigner / WatermarkGenerator), mirroring Flink's
+/// WatermarkAssignerOperator idleness semantics.
+///
+/// A non-positive idleTimeout disables idleness detection.
+///
+/// All methods are non-thread-safe and must be invoked from the same thread
+/// that drives the owning operator. The background timer is responsible only
+/// for waking up the Java mailbox via NativeCallbackBridge; the actual idle
+/// state transition is performed here, on the driver thread, during the drain
+/// triggered by that wake-up.
+class WatermarkIdleTracker {
+ public:
+  explicit WatermarkIdleTracker(int64_t idleTimeoutMs);
+
+  /// Notifies that input data has arrived at the given wall-clock time.
+  /// Returns true if the tracker was previously idle, signalling the caller
+  /// to emit WatermarkStatus.ACTIVE.
+  bool onRecord(int64_t currentWallMs);
+
+  /// Periodically checks whether the input has been idle long enough to
+  /// transition to the IDLE status. Returns true if the tracker just became
+  /// idle, signalling the caller to emit WatermarkStatus.IDLE. Returns false
+  /// when idleness detection is disabled, when the tracker is already idle, or
+  /// when the idle timeout has not yet elapsed.
+  bool checkIdle(int64_t currentWallMs);
+
+  bool isIdle() const;
+
+  bool isEnabled() const;
+
+  void setIdle(bool idle);
+
+ private:
+  const int64_t idleTimeout_;
+  int64_t lastRecordWallTime_{0};
+  bool idle_{false};
+};
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkIdleTracker.h
+++ b/velox/experimental/stateful/WatermarkIdleTracker.h
@@ -55,6 +55,7 @@ class WatermarkIdleTracker {
   const int64_t idleTimeout_;
   int64_t lastRecordWallTime_{0};
   bool idle_{false};
+  bool baselineInitialized_{false};
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkIdleTracker.h
+++ b/velox/experimental/stateful/WatermarkIdleTracker.h
@@ -49,6 +49,8 @@ class WatermarkIdleTracker {
 
   bool isEnabled() const;
 
+  int64_t idleDeadline() const;
+
   void setIdle(bool idle);
 
  private:

--- a/velox/experimental/stateful/WatermarkSource.cpp
+++ b/velox/experimental/stateful/WatermarkSource.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/experimental/stateful/WatermarkSource.h"
 
+#include "velox/experimental/stateful/window/TimeWindowUtil.h"
+
 namespace facebook::velox::stateful {
 
 WatermarkSource::WatermarkSource(
@@ -24,6 +26,10 @@ WatermarkSource::WatermarkSource(
     : StatefulOperator(std::move(op), std::move(targets)),
       watermarkGenerator_(std::move(watermarkGenerator)) {
   VELOX_CHECK_NOT_NULL(watermarkGenerator_);
+}
+
+WatermarkSource::~WatermarkSource() {
+  WatermarkSource::close();
 }
 
 void WatermarkSource::initialize() {
@@ -50,9 +56,56 @@ void WatermarkSource::advance() {
   if (watermark.has_value()) {
     emitWatermark(watermark.value());
   }
+
+  if (watermarkGenerator_->isIdlenessEnabled()) {
+    int64_t now = TimeWindowUtil::getCurrentProcessingTime();
+    if (watermarkGenerator_->onRecord(now)) {
+      emitWatermarkStatus(false);
+    }
+    scheduleIdleTimer(now);
+  }
+}
+
+void WatermarkSource::checkWatermarkStatus(int64_t now) {
+  if (!watermarkGenerator_->isIdlenessEnabled()) {
+    StatefulOperator::checkWatermarkStatus(now);
+    return;
+  }
+
+  if (idleCheckRequested_.exchange(false)) {
+    if (watermarkGenerator_->checkIdle(now)) {
+      emitWatermarkStatus(true);
+    }
+    scheduleIdleTimer(now);
+  }
+
+  StatefulOperator::checkWatermarkStatus(now);
+}
+
+void WatermarkSource::scheduleIdleTimer(int64_t now) {
+  if (!scheduler_) {
+    scheduler_ = std::make_unique<SystemProcessingTimeScheduler>();
+  }
+  int64_t fireAt = now + watermarkGenerator_->idleTimeout();
+  scheduler_->registerTimer(
+      fireAt, ProcessingTimerTask(fireAt, [this](int64_t timestamp) {
+        onIdleTimerFired(timestamp);
+      }));
+}
+
+void WatermarkSource::onIdleTimerFired(int64_t timestamp) {
+  idleCheckRequested_.store(true);
+  auto bridge = nativeCallbackBridge();
+  if (bridge) {
+    bridge->onProcessingTime(timestamp);
+  }
 }
 
 void WatermarkSource::close() {
+  if (scheduler_) {
+    scheduler_->close();
+    scheduler_.reset();
+  }
   if (watermarkGenerator_) {
     watermarkGenerator_->close();
     watermarkGenerator_.reset();

--- a/velox/experimental/stateful/WatermarkSource.cpp
+++ b/velox/experimental/stateful/WatermarkSource.cpp
@@ -71,10 +71,8 @@ void WatermarkSource::checkWatermarkStatus(int64_t now) {
     return;
   }
 
-  if (idleCheckRequested_.exchange(false)) {
-    if (watermarkGenerator_->checkIdle(now)) {
-      emitWatermarkStatus(true);
-    }
+  if (watermarkGenerator_->checkIdle(now)) {
+    emitWatermarkStatus(true);
   }
 
   scheduleIdleTimer(now);
@@ -98,7 +96,6 @@ void WatermarkSource::scheduleIdleTimer(int64_t now) {
 
 void WatermarkSource::onIdleTimerFired(int64_t timestamp) {
   timerPending_ = false;
-  idleCheckRequested_.store(true);
   auto bridge = nativeCallbackBridge();
   if (bridge) {
     bridge->onProcessingTime(timestamp);

--- a/velox/experimental/stateful/WatermarkSource.cpp
+++ b/velox/experimental/stateful/WatermarkSource.cpp
@@ -62,7 +62,6 @@ void WatermarkSource::advance() {
     if (watermarkGenerator_->onRecord(now)) {
       emitWatermarkStatus(false);
     }
-    scheduleIdleTimer(now);
   }
 }
 
@@ -76,13 +75,17 @@ void WatermarkSource::checkWatermarkStatus(int64_t now) {
     if (watermarkGenerator_->checkIdle(now)) {
       emitWatermarkStatus(true);
     }
-    scheduleIdleTimer(now);
   }
+
+  scheduleIdleTimer(now);
 
   StatefulOperator::checkWatermarkStatus(now);
 }
 
 void WatermarkSource::scheduleIdleTimer(int64_t now) {
+  if (timerPending_.exchange(true)) {
+    return;
+  }
   if (!scheduler_) {
     scheduler_ = std::make_unique<SystemProcessingTimeScheduler>();
   }
@@ -94,6 +97,7 @@ void WatermarkSource::scheduleIdleTimer(int64_t now) {
 }
 
 void WatermarkSource::onIdleTimerFired(int64_t timestamp) {
+  timerPending_ = false;
   idleCheckRequested_.store(true);
   auto bridge = nativeCallbackBridge();
   if (bridge) {

--- a/velox/experimental/stateful/WatermarkSource.cpp
+++ b/velox/experimental/stateful/WatermarkSource.cpp
@@ -29,7 +29,7 @@ WatermarkSource::WatermarkSource(
 }
 
 WatermarkSource::~WatermarkSource() {
-  WatermarkSource::close();
+  shutdownScheduler();
 }
 
 void WatermarkSource::initialize() {
@@ -94,8 +94,12 @@ void WatermarkSource::scheduleIdleTimer(int64_t now) {
       });
 }
 
-void WatermarkSource::close() {
+void WatermarkSource::shutdownScheduler() {
   idleTimerManager_.shutdown();
+}
+
+void WatermarkSource::close() {
+  shutdownScheduler();
   if (watermarkGenerator_) {
     watermarkGenerator_->close();
     watermarkGenerator_.reset();

--- a/velox/experimental/stateful/WatermarkSource.cpp
+++ b/velox/experimental/stateful/WatermarkSource.cpp
@@ -81,32 +81,21 @@ void WatermarkSource::checkWatermarkStatus(int64_t now) {
 }
 
 void WatermarkSource::scheduleIdleTimer(int64_t now) {
-  if (timerPending_.exchange(true)) {
-    return;
-  }
-  if (!scheduler_) {
-    scheduler_ = std::make_unique<SystemProcessingTimeScheduler>();
-  }
-  int64_t fireAt = now + watermarkGenerator_->idleTimeout();
-  scheduler_->registerTimer(
-      fireAt, ProcessingTimerTask(fireAt, [this](int64_t timestamp) {
-        onIdleTimerFired(timestamp);
-      }));
-}
-
-void WatermarkSource::onIdleTimerFired(int64_t timestamp) {
-  timerPending_ = false;
-  auto bridge = nativeCallbackBridge();
-  if (bridge) {
-    bridge->onProcessingTime(timestamp);
-  }
+  idleTimerManager_.schedule(
+      now,
+      watermarkGenerator_->isIdlenessEnabled(),
+      watermarkGenerator_->isIdle(),
+      watermarkGenerator_->idleDeadline(),
+      [this](int64_t timestamp) {
+        auto bridge = nativeCallbackBridge();
+        if (bridge) {
+          bridge->onProcessingTime(timestamp);
+        }
+      });
 }
 
 void WatermarkSource::close() {
-  if (scheduler_) {
-    scheduler_->close();
-    scheduler_.reset();
-  }
+  idleTimerManager_.shutdown();
   if (watermarkGenerator_) {
     watermarkGenerator_->close();
     watermarkGenerator_.reset();

--- a/velox/experimental/stateful/WatermarkSource.h
+++ b/velox/experimental/stateful/WatermarkSource.h
@@ -61,6 +61,7 @@ class WatermarkSource : public StatefulOperator {
   std::unique_ptr<WatermarkGenerator> watermarkGenerator_;
   std::unique_ptr<ProcessingTimeScheduler> scheduler_;
   std::atomic<bool> idleCheckRequested_{false};
+  std::atomic<bool> timerPending_{false};
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkSource.h
+++ b/velox/experimental/stateful/WatermarkSource.h
@@ -59,6 +59,8 @@ class WatermarkSource : public StatefulOperator {
   /// WatermarkStatus event.
   void scheduleIdleTimer(int64_t now);
 
+  void shutdownScheduler();
+
   std::unique_ptr<WatermarkGenerator> watermarkGenerator_;
   IdleTimerManager idleTimerManager_;
 };

--- a/velox/experimental/stateful/WatermarkSource.h
+++ b/velox/experimental/stateful/WatermarkSource.h
@@ -60,7 +60,6 @@ class WatermarkSource : public StatefulOperator {
 
   std::unique_ptr<WatermarkGenerator> watermarkGenerator_;
   std::unique_ptr<ProcessingTimeScheduler> scheduler_;
-  std::atomic<bool> idleCheckRequested_{false};
   std::atomic<bool> timerPending_{false};
 };
 

--- a/velox/experimental/stateful/WatermarkSource.h
+++ b/velox/experimental/stateful/WatermarkSource.h
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 #pragma once
-#include <atomic>
 #include <cstdint>
 #include <memory>
 
-#include "velox/experimental/stateful/ProcessingTimeScheduler.h"
+#include "velox/experimental/stateful/IdleTimerManager.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
 #include "velox/experimental/stateful/WatermarkGenerator.h"
 
@@ -54,13 +53,14 @@ class WatermarkSource : public StatefulOperator {
   }
 
  private:
+  /// Schedules a one-shot idle-detection timer on the background
+  /// processing-time scheduler. When the timer fires it wakes the Java mailbox
+  /// via the native callback bridge so the driver thread can drain any emitted
+  /// WatermarkStatus event.
   void scheduleIdleTimer(int64_t now);
 
-  void onIdleTimerFired(int64_t timestamp);
-
   std::unique_ptr<WatermarkGenerator> watermarkGenerator_;
-  std::unique_ptr<ProcessingTimeScheduler> scheduler_;
-  std::atomic<bool> timerPending_{false};
+  IdleTimerManager idleTimerManager_;
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/WatermarkSource.h
+++ b/velox/experimental/stateful/WatermarkSource.h
@@ -14,12 +14,21 @@
  * limitations under the License.
  */
 #pragma once
+#include <atomic>
+#include <cstdint>
+#include <memory>
 
+#include "velox/experimental/stateful/ProcessingTimeScheduler.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
 #include "velox/experimental/stateful/WatermarkGenerator.h"
 
 namespace facebook::velox::stateful {
 
+/// WatermarkSource wraps a source operator and generates watermarks from the
+/// source output using WatermarkGenerator. When an idle timeout is configured
+/// on the generator, the source also detects idle input (no source output for
+/// the idle timeout duration) and emits WatermarkStatus.IDLE / ACTIVE
+/// downstream, mirroring Flink's source-level idleness semantics.
 class WatermarkSource : public StatefulOperator {
  public:
   WatermarkSource(
@@ -27,18 +36,31 @@ class WatermarkSource : public StatefulOperator {
       std::vector<StatefulOperatorPtr> targets,
       std::unique_ptr<WatermarkGenerator> watermarkGenerator);
 
+  ~WatermarkSource() override;
+
   void initialize() override;
 
   void advance() override;
 
   void close() override;
 
+  /// Invoked by the driver thread (via StatefulTask::next) after each drain
+  /// attempt. Performs the idle check and emits WatermarkStatus if the source
+  /// has just transitioned to idle.
+  void checkWatermarkStatus(int64_t now) override;
+
   std::string name() const override {
     return "WatermarkSource";
   }
 
  private:
+  void scheduleIdleTimer(int64_t now);
+
+  void onIdleTimerFired(int64_t timestamp);
+
   std::unique_ptr<WatermarkGenerator> watermarkGenerator_;
+  std::unique_ptr<ProcessingTimeScheduler> scheduler_;
+  std::atomic<bool> idleCheckRequested_{false};
 };
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/tests/CMakeLists.txt
+++ b/velox/experimental/stateful/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ add_executable(velox_stateful_combined_watermark_status_test
 add_executable(velox_stateful_watermark_idle_tracker_test
                WatermarkIdleTrackerTest.cpp ../WatermarkIdleTracker.cpp)
 
+add_executable(velox_stateful_idle_timer_manager_test IdleTimerManagerTest.cpp)
+
 add_test(velox_stateful_watermark_generator_test
          velox_stateful_watermark_generator_test)
 
@@ -30,12 +32,19 @@ add_test(velox_stateful_combined_watermark_status_test
 add_test(velox_stateful_watermark_idle_tracker_test
          velox_stateful_watermark_idle_tracker_test)
 
+add_test(velox_stateful_idle_timer_manager_test
+         velox_stateful_idle_timer_manager_test)
+
 target_link_libraries(
   velox_stateful_combined_watermark_status_test velox_common_base GTest::gtest
   GTest::gtest_main)
 
 target_link_libraries(
   velox_stateful_watermark_idle_tracker_test velox_common_base GTest::gtest
+  GTest::gtest_main)
+
+target_link_libraries(
+  velox_stateful_idle_timer_manager_test velox_common_base GTest::gtest
   GTest::gtest_main)
 
 target_link_libraries(

--- a/velox/experimental/stateful/tests/CMakeLists.txt
+++ b/velox/experimental/stateful/tests/CMakeLists.txt
@@ -18,14 +18,24 @@ add_executable(velox_stateful_watermark_generator_test
 add_executable(velox_stateful_combined_watermark_status_test
                CombinedWatermarkStatusTest.cpp ../CombinedWatermarkStatus.cpp)
 
+add_executable(velox_stateful_watermark_idle_tracker_test
+               WatermarkIdleTrackerTest.cpp ../WatermarkIdleTracker.cpp)
+
 add_test(velox_stateful_watermark_generator_test
          velox_stateful_watermark_generator_test)
 
 add_test(velox_stateful_combined_watermark_status_test
          velox_stateful_combined_watermark_status_test)
 
+add_test(velox_stateful_watermark_idle_tracker_test
+         velox_stateful_watermark_idle_tracker_test)
+
 target_link_libraries(
   velox_stateful_combined_watermark_status_test velox_common_base GTest::gtest
+  GTest::gtest_main)
+
+target_link_libraries(
+  velox_stateful_watermark_idle_tracker_test velox_common_base GTest::gtest
   GTest::gtest_main)
 
 target_link_libraries(

--- a/velox/experimental/stateful/tests/IdleTimerManagerTest.cpp
+++ b/velox/experimental/stateful/tests/IdleTimerManagerTest.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/stateful/IdleTimerManager.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::stateful::test {
+namespace {
+
+class FakeProcessingTimeScheduler : public ProcessingTimeScheduler {
+ public:
+  std::optional<std::string> registerTimer(
+      int64_t timestamp,
+      ProcessingTimerTask task) override {
+    timestamps_.push_back(timestamp);
+    tasks_.push_back(std::move(task));
+    return std::to_string(timestamps_.size());
+  }
+
+  void fireLast() {
+    tasks_.back()();
+  }
+
+  const std::vector<int64_t>& timestamps() const {
+    return timestamps_;
+  }
+
+ private:
+  std::vector<int64_t> timestamps_;
+  std::vector<ProcessingTimerTask> tasks_;
+};
+
+TEST(IdleTimerManagerTest, schedulesAtIdleDeadline) {
+  auto scheduler = std::make_unique<FakeProcessingTimeScheduler>();
+  auto* schedulerPtr = scheduler.get();
+  IdleTimerManager manager(std::move(scheduler));
+
+  std::vector<int64_t> fired;
+  manager.schedule(
+      1'000,
+      true,
+      false,
+      1'100,
+      [&](int64_t timestamp) { fired.push_back(timestamp); });
+
+  EXPECT_EQ((std::vector<int64_t>{1'100}), schedulerPtr->timestamps());
+  schedulerPtr->fireLast();
+  EXPECT_EQ((std::vector<int64_t>{1'100}), fired);
+}
+
+TEST(IdleTimerManagerTest, doesNotRearmWhileTimerIsPending) {
+  auto scheduler = std::make_unique<FakeProcessingTimeScheduler>();
+  auto* schedulerPtr = scheduler.get();
+  IdleTimerManager manager(std::move(scheduler));
+
+  manager.schedule(1'000, true, false, 1'100, [](int64_t) {});
+  manager.schedule(1'050, true, false, 1'150, [](int64_t) {});
+
+  EXPECT_EQ((std::vector<int64_t>{1'100}), schedulerPtr->timestamps());
+}
+
+TEST(IdleTimerManagerTest, canRearmAfterTimerFires) {
+  auto scheduler = std::make_unique<FakeProcessingTimeScheduler>();
+  auto* schedulerPtr = scheduler.get();
+  IdleTimerManager manager(std::move(scheduler));
+
+  manager.schedule(1'000, true, false, 1'100, [](int64_t) {});
+  schedulerPtr->fireLast();
+  manager.schedule(1'200, true, false, 1'300, [](int64_t) {});
+
+  EXPECT_EQ((std::vector<int64_t>{1'100, 1'300}), schedulerPtr->timestamps());
+}
+
+TEST(IdleTimerManagerTest, alreadyIdleDoesNotArmTimer) {
+  auto scheduler = std::make_unique<FakeProcessingTimeScheduler>();
+  auto* schedulerPtr = scheduler.get();
+  IdleTimerManager manager(std::move(scheduler));
+
+  manager.schedule(1'000, true, true, 1'100, [](int64_t) {});
+
+  EXPECT_TRUE(schedulerPtr->timestamps().empty());
+}
+
+} // namespace
+} // namespace facebook::velox::stateful::test
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/velox/experimental/stateful/tests/IdleTimerManagerTest.cpp
+++ b/velox/experimental/stateful/tests/IdleTimerManagerTest.cpp
@@ -50,12 +50,9 @@ TEST(IdleTimerManagerTest, schedulesAtIdleDeadline) {
   IdleTimerManager manager(std::move(scheduler));
 
   std::vector<int64_t> fired;
-  manager.schedule(
-      1'000,
-      true,
-      false,
-      1'100,
-      [&](int64_t timestamp) { fired.push_back(timestamp); });
+  manager.schedule(1'000, true, false, 1'100, [&](int64_t timestamp) {
+    fired.push_back(timestamp);
+  });
 
   EXPECT_EQ((std::vector<int64_t>{1'100}), schedulerPtr->timestamps());
   schedulerPtr->fireLast();

--- a/velox/experimental/stateful/tests/WatermarkGeneratorTest.cpp
+++ b/velox/experimental/stateful/tests/WatermarkGeneratorTest.cpp
@@ -116,6 +116,47 @@ class QueuedOutputOperator : public exec::Operator {
   size_t nextOutput_{0};
 };
 
+class BlockingOutputOperator : public exec::Operator {
+ public:
+  BlockingOutputOperator(exec::DriverCtx* driverCtx, RowVectorPtr firstOutput)
+      : Operator(
+            driverCtx,
+            ROW({"timestamp"}, {BIGINT()}),
+            0,
+            "blocking_output",
+            "BlockingOutput"),
+        firstOutput_(std::move(firstOutput)) {}
+
+  bool needsInput() const override {
+    return false;
+  }
+
+  void addInput(RowVectorPtr) override {}
+
+  RowVectorPtr getOutput() override {
+    if (firstOutput_) {
+      return std::move(firstOutput_);
+    }
+    return nullptr;
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture* future) override {
+    auto [promise, blockedFuture] = makeVeloxContinuePromiseContract(
+        "WatermarkGeneratorTest.BlockingOutputOperator");
+    promises_.push_back(std::move(promise));
+    *future = std::move(blockedFuture);
+    return exec::BlockingReason::kWaitForConnector;
+  }
+
+  bool isFinished() override {
+    return false;
+  }
+
+ private:
+  RowVectorPtr firstOutput_;
+  std::vector<ContinuePromise> promises_;
+};
+
 class NoOutputOperator : public exec::Operator {
  public:
   explicit NoOutputOperator(exec::DriverCtx* driverCtx)
@@ -167,6 +208,11 @@ class SpyStatefulOperator : public StatefulOperator {
     watermarks_.push_back(timestamp);
   }
 
+  void processWatermarkStatus(bool idle) override {
+    events_.push_back(idle ? "idle" : "active");
+    watermarkStatuses_.push_back(idle);
+  }
+
   size_t numRecords() const {
     return numRecords_;
   }
@@ -179,6 +225,10 @@ class SpyStatefulOperator : public StatefulOperator {
     return events_;
   }
 
+  const std::vector<bool>& watermarkStatuses() const {
+    return watermarkStatuses_;
+  }
+
   const std::vector<vector_size_t>& recordSizes() const {
     return recordSizes_;
   }
@@ -188,6 +238,7 @@ class SpyStatefulOperator : public StatefulOperator {
   std::vector<std::string> events_;
   std::vector<vector_size_t> recordSizes_;
   std::vector<int64_t> watermarks_;
+  std::vector<bool> watermarkStatuses_;
 };
 
 class WatermarkGeneratorTest : public exec::test::OperatorTestBase {
@@ -457,6 +508,113 @@ TEST_F(WatermarkGeneratorTest, watermarkSourceTracksSourceEmpty) {
 
   watermarkSource.advance();
   EXPECT_TRUE(watermarkSource.sourceEmpty());
+}
+
+TEST_F(WatermarkGeneratorTest, watermarkAssignerIdleActiveAndSecondIdle) {
+  auto spy = std::make_unique<SpyStatefulOperator>(driverCtx_.get());
+  auto* spyPtr = spy.get();
+  std::vector<StatefulOperatorPtr> targets;
+  targets.push_back(std::move(spy));
+
+  WatermarkAssigner watermarkAssigner(
+      std::make_unique<TimestampProjectionOperator>(driverCtx_.get()),
+      std::move(targets),
+      100,
+      0,
+      1000);
+
+  watermarkAssigner.addInput(
+      std::make_shared<StreamRecord>("input", batch({1'000})));
+  watermarkAssigner.advance();
+  const auto firstRecordTime = TimeWindowUtil::getCurrentProcessingTime();
+
+  watermarkAssigner.checkWatermarkStatus(firstRecordTime + 99);
+  EXPECT_TRUE(spyPtr->watermarkStatuses().empty());
+
+  watermarkAssigner.checkWatermarkStatus(firstRecordTime + 101);
+  EXPECT_EQ((std::vector<bool>{true}), spyPtr->watermarkStatuses());
+
+  // Already-idle inputs must not re-emit IDLE on later checks.
+  watermarkAssigner.checkWatermarkStatus(10'000);
+  EXPECT_EQ((std::vector<bool>{true}), spyPtr->watermarkStatuses());
+
+  watermarkAssigner.addInput(
+      std::make_shared<StreamRecord>("input", batch({2'000})));
+  watermarkAssigner.advance();
+  const auto secondRecordTime = TimeWindowUtil::getCurrentProcessingTime();
+  EXPECT_EQ((std::vector<bool>{true, false}), spyPtr->watermarkStatuses());
+
+  watermarkAssigner.checkWatermarkStatus(secondRecordTime + 101);
+  EXPECT_EQ(
+      (std::vector<bool>{true, false, true}), spyPtr->watermarkStatuses());
+}
+
+TEST_F(WatermarkGeneratorTest, watermarkSourceIdleActiveAndSecondIdle) {
+  auto spy = std::make_unique<SpyStatefulOperator>(driverCtx_.get());
+  auto* spyPtr = spy.get();
+  std::vector<StatefulOperatorPtr> targets;
+  targets.push_back(std::move(spy));
+
+  WatermarkSource watermarkSource(
+      std::make_unique<QueuedOutputOperator>(
+          driverCtx_.get(),
+          std::vector<RowVectorPtr>{batch({1'000}), batch({2'000})}),
+      std::move(targets),
+      std::make_unique<WatermarkGenerator>(
+          std::make_unique<TimestampProjectionOperator>(driverCtx_.get()),
+          100,
+          0,
+          1000));
+
+  watermarkSource.advance();
+  const auto firstRecordTime = TimeWindowUtil::getCurrentProcessingTime();
+
+  watermarkSource.checkWatermarkStatus(firstRecordTime + 99);
+  EXPECT_TRUE(spyPtr->watermarkStatuses().empty());
+
+  watermarkSource.checkWatermarkStatus(firstRecordTime + 101);
+  EXPECT_EQ((std::vector<bool>{true}), spyPtr->watermarkStatuses());
+
+  // Already-idle sources must not re-emit IDLE on later checks.
+  watermarkSource.checkWatermarkStatus(10'000);
+  EXPECT_EQ((std::vector<bool>{true}), spyPtr->watermarkStatuses());
+
+  watermarkSource.advance();
+  const auto secondRecordTime = TimeWindowUtil::getCurrentProcessingTime();
+  EXPECT_EQ((std::vector<bool>{true, false}), spyPtr->watermarkStatuses());
+
+  watermarkSource.checkWatermarkStatus(secondRecordTime + 101);
+  EXPECT_EQ(
+      (std::vector<bool>{true, false, true}), spyPtr->watermarkStatuses());
+}
+
+TEST_F(WatermarkGeneratorTest, blockedSourceCheckEmitsIdleInSameDrainCycle) {
+  auto spy = std::make_unique<SpyStatefulOperator>(driverCtx_.get());
+  auto* spyPtr = spy.get();
+  std::vector<StatefulOperatorPtr> targets;
+  targets.push_back(std::move(spy));
+
+  WatermarkSource watermarkSource(
+      std::make_unique<BlockingOutputOperator>(
+          driverCtx_.get(), batch({1'000})),
+      std::move(targets),
+      std::make_unique<WatermarkGenerator>(
+          std::make_unique<TimestampProjectionOperator>(driverCtx_.get()),
+          100,
+          0,
+          1000));
+
+  watermarkSource.advance();
+  const auto recordTime = TimeWindowUtil::getCurrentProcessingTime();
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  watermarkSource.advanceWithFuture(&future);
+  EXPECT_TRUE(future.valid());
+
+  // Mirrors StatefulTask::next(): after a source blocks, the same drain cycle
+  // gives the operator a chance to emit WatermarkStatus.IDLE.
+  watermarkSource.checkWatermarkStatus(recordTime + 101);
+  EXPECT_EQ((std::vector<bool>{true}), spyPtr->watermarkStatuses());
 }
 
 } // namespace

--- a/velox/experimental/stateful/tests/WatermarkIdleTrackerTest.cpp
+++ b/velox/experimental/stateful/tests/WatermarkIdleTrackerTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/stateful/WatermarkIdleTracker.h"
+#include <gtest/gtest.h>
+
+namespace facebook::velox::stateful::test {
+namespace {
+
+TEST(WatermarkIdleTrackerTest, disabledWhenIdleTimeoutNonPositive) {
+  WatermarkIdleTracker tracker(0);
+  EXPECT_FALSE(tracker.isEnabled());
+  EXPECT_FALSE(tracker.onRecord(1000));
+  EXPECT_FALSE(tracker.checkIdle(10'000));
+  EXPECT_FALSE(tracker.isIdle());
+
+  WatermarkIdleTracker negativeTracker(-1);
+  EXPECT_FALSE(negativeTracker.isEnabled());
+}
+
+TEST(WatermarkIdleTrackerTest, onRecordReturnsFalseWhenNotIdle) {
+  WatermarkIdleTracker tracker(5'000);
+  EXPECT_FALSE(tracker.onRecord(1'000));
+  EXPECT_FALSE(tracker.isIdle());
+}
+
+TEST(WatermarkIdleTrackerTest, emitsIdleWhenTimeoutElapses) {
+  WatermarkIdleTracker tracker(5'000);
+  tracker.onRecord(1'000);
+  EXPECT_FALSE(tracker.checkIdle(4'000));
+  EXPECT_FALSE(tracker.isIdle());
+  EXPECT_TRUE(tracker.checkIdle(6'001));
+  EXPECT_TRUE(tracker.isIdle());
+}
+
+TEST(WatermarkIdleTrackerTest, doesNotEmitIdleTwice) {
+  WatermarkIdleTracker tracker(5'000);
+  tracker.onRecord(1'000);
+  EXPECT_TRUE(tracker.checkIdle(6'001));
+  EXPECT_FALSE(tracker.checkIdle(20'000));
+  EXPECT_TRUE(tracker.isIdle());
+}
+
+TEST(WatermarkIdleTrackerTest, onRecordReactivatesFromIdle) {
+  WatermarkIdleTracker tracker(5'000);
+  tracker.onRecord(1'000);
+  tracker.checkIdle(6'001);
+  EXPECT_TRUE(tracker.isIdle());
+
+  EXPECT_TRUE(tracker.onRecord(7'000));
+  EXPECT_FALSE(tracker.isIdle());
+  EXPECT_FALSE(tracker.onRecord(8'000));
+}
+
+TEST(WatermarkIdleTrackerTest, checkIdleAfterReactivationDoesNotFireEarly) {
+  WatermarkIdleTracker tracker(5'000);
+  tracker.onRecord(1'000);
+  tracker.checkIdle(6'001);
+  tracker.onRecord(7'000);
+  EXPECT_FALSE(tracker.checkIdle(9'000));
+  EXPECT_FALSE(tracker.isIdle());
+  EXPECT_TRUE(tracker.checkIdle(12'001));
+}
+
+TEST(WatermarkIdleTrackerTest, firstCheckSetsBaselineWithoutFiring) {
+  WatermarkIdleTracker tracker(5'000);
+  EXPECT_FALSE(tracker.checkIdle(100'000));
+  EXPECT_FALSE(tracker.isIdle());
+  tracker.onRecord(101'000);
+  EXPECT_FALSE(tracker.checkIdle(103'000));
+  EXPECT_TRUE(tracker.checkIdle(106'001));
+}
+
+TEST(WatermarkIdleTrackerTest, exactTimeoutDoesNotFire) {
+  WatermarkIdleTracker tracker(5'000);
+  tracker.onRecord(1'000);
+  EXPECT_FALSE(tracker.checkIdle(6'000));
+  EXPECT_FALSE(tracker.isIdle());
+}
+
+TEST(WatermarkIdleTrackerTest, setIdleTransitionsState) {
+  WatermarkIdleTracker tracker(5'000);
+  tracker.setIdle(true);
+  EXPECT_TRUE(tracker.isIdle());
+  tracker.setIdle(false);
+  EXPECT_FALSE(tracker.isIdle());
+}
+
+} // namespace
+} // namespace facebook::velox::stateful::test
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/velox/experimental/stateful/tests/WatermarkIdleTrackerTest.cpp
+++ b/velox/experimental/stateful/tests/WatermarkIdleTrackerTest.cpp
@@ -74,6 +74,17 @@ TEST(WatermarkIdleTrackerTest, checkIdleAfterReactivationDoesNotFireEarly) {
   EXPECT_TRUE(tracker.checkIdle(12'001));
 }
 
+TEST(WatermarkIdleTrackerTest, repeatedCheckIdleDoesNotResetBaseline) {
+  WatermarkIdleTracker tracker(5'000);
+  // First call sets baseline at 100'000.
+  EXPECT_FALSE(tracker.checkIdle(100'000));
+  // Subsequent calls must not reset the baseline.
+  EXPECT_FALSE(tracker.checkIdle(102'000));
+  EXPECT_FALSE(tracker.checkIdle(104'000));
+  // Timeout measured from the original baseline.
+  EXPECT_TRUE(tracker.checkIdle(106'000));
+}
+
 TEST(WatermarkIdleTrackerTest, firstCheckSetsBaselineWithoutFiring) {
   WatermarkIdleTracker tracker(5'000);
   EXPECT_FALSE(tracker.checkIdle(100'000));


### PR DESCRIPTION
## Summary

Implements idle source handling for Gluten Flink (issue apache/gluten#12340), using native `SystemProcessingTimeScheduler` timer + `NativeCallbackBridge->onProcessingTime` to detect idle input and emit `WatermarkStatus.IDLE/ACTIVE`.

## Changes

### New files
- `WatermarkIdleTracker.h/.cpp` — Pure-logic idle detection class (`onRecord`, `checkIdle`, `isIdle`, `isEnabled`)
- `tests/WatermarkIdleTrackerTest.cpp` — 9 unit tests

### Modified files
- `WatermarkAssigner.h/.cpp` — Integrate idleTracker + `SystemProcessingTimeScheduler` timer + `callbackBridge->onProcessingTime`; emit ACTIVE on data arrival, IDLE via `checkWatermarkStatus()` hook
- `WatermarkGenerator.h/.cpp` — Add `WatermarkIdleTracker` member, expose `onRecord`/`checkIdle`/`idleTimeout` for source-level use
- `WatermarkSource.h/.cpp` — Same timer+idle pattern as WatermarkAssigner for source-level watermark pushdown
- `StatefulOperator.h/.cpp` — Add `virtual ~StatefulOperator() = default` and `virtual void checkWatermarkStatus(int64_t now)` with recursive forwarding to targets
- `StatefulTask.h/.cpp` — Call `checkWatermarkStatus()` in `next()` after each drain attempt (both blocked and empty-output paths)
- `CMakeLists.txt` — Register new source files

## Design
- Timer callback only sets `std::atomic<bool>` flag + calls bridge to wake Java mailbox — never writes to `pendings_` directly
- Actual idle check + `emitWatermarkStatus` happens on driver thread in `checkWatermarkStatus()`, avoiding races
- `checkWatermarkStatus` is called on every drain attempt, so idle detection works even without callback bridge (e.g. WatermarkSource path)

## Verification
- All 9 new `WatermarkIdleTracker` unit tests pass
- `libvelox.so` compiles successfully in Docker container `lgbo_flink_native_compile`
- velox4j and gluten-flink compile successfully with 63 existing tests passing