### PR TITLE
feat: Support RowKind

### DIFF
--- a/velox/experimental/stateful/CMakeLists.txt
+++ b/velox/experimental/stateful/CMakeLists.txt
@@ -39,7 +39,8 @@ velox_add_library(
   WatermarkSource.cpp
   WatermarkAssigner.cpp
   StreamRecordTimestampInserter.cpp
-  WatermarkIdleTracker.cpp)
+  WatermarkIdleTracker.cpp
+  StreamElement.cpp)
 
 velox_link_libraries(
   velox_stateful_exec

--- a/velox/experimental/stateful/GroupWindowAggregator.cpp
+++ b/velox/experimental/stateful/GroupWindowAggregator.cpp
@@ -75,6 +75,7 @@ void GroupWindowAggregator::initializeState() {
 void GroupWindowAggregator::addInput(StreamElementPtr input) {
   VELOX_CHECK(!input_, "Last input has not been processed");
   auto record = std::static_pointer_cast<StreamRecord>(input);
+  // TODO: preserve rowKind across this operator.
   input_ = record->record();
 }
 

--- a/velox/experimental/stateful/LocalWindowAggregator.cpp
+++ b/velox/experimental/stateful/LocalWindowAggregator.cpp
@@ -41,6 +41,7 @@ LocalWindowAggregator::LocalWindowAggregator(
 void LocalWindowAggregator::addInput(StreamElementPtr input) {
   VELOX_CHECK(!input_, "Last input has not been processed");
   auto record = std::static_pointer_cast<StreamRecord>(input);
+  // TODO: preserve rowKind across this operator.
   input_ = record->record();
 }
 

--- a/velox/experimental/stateful/RowKind.h
+++ b/velox/experimental/stateful/RowKind.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace facebook::velox::stateful {
+
+enum class RowKind : int8_t {
+  INSERT = 0,
+  UPDATE_BEFORE = 1,
+  UPDATE_AFTER = 2,
+  DELETE = 3,
+};
+
+// Name of the synthetic trailing column that carries RowKind across the JNI
+// boundary inside a merged RowVector.
+constexpr std::string_view kRowKindColumnName = "$row_kind";
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/StatefulOperator.cpp
+++ b/velox/experimental/stateful/StatefulOperator.cpp
@@ -54,8 +54,9 @@ bool StatefulOperator::isFinished() {
 
 void StatefulOperator::addInput(StreamElementPtr input) {
   auto record = std::static_pointer_cast<StreamRecord>(input);
-  operator_->traceInput(record->record());
-  operator_->addInput(record->record());
+  const auto& rowVector = record->record();
+  operator_->traceInput(rowVector);
+  operator_->addInput(rowVector);
 }
 
 bool StatefulOperator::sourceEmpty() {

--- a/velox/experimental/stateful/StatefulOperator.h
+++ b/velox/experimental/stateful/StatefulOperator.h
@@ -47,7 +47,7 @@ class StatefulOperator {
       : keyedStateBackendParameters_(keyedStateBackendParameters),
         operator_(std::move(op)),
         targets_(std::move(targets)) {
-    sink = operator_->operatorType() == "TableWrite";
+    sink_ = operator_->operatorType() == "TableWrite";
   }
 
   virtual ~StatefulOperator() = default;
@@ -56,8 +56,17 @@ class StatefulOperator {
 
   virtual bool isFinished();
 
+  // Receives a StreamRecord and feeds value() to the underlying velox operator.
+  // The base implementation drops rowKind, which is correct for stateless
+  // passthrough. Operators with retract semantics (group aggregation, stream
+  // join, etc.) must override this and advance() to act on rowKind.
   virtual void addInput(StreamElementPtr input);
 
+  // Pulls the next output batch from the underlying velox operator and wraps it
+  // as a StreamRecord. The base implementation assumes appendOnly output (no
+  // $row_kind column), which matches stateless passthrough. Operators with
+  // retract semantics must override this together with addInput() to emit
+  // rowKind according to their changelog semantics.
   virtual void advance();
 
   void advanceWithFuture(ContinueFuture* future);
@@ -161,7 +170,7 @@ class StatefulOperator {
 
  private:
   bool isSink() {
-    return sink;
+    return sink_;
   }
 
   bool isSource() const {
@@ -170,7 +179,7 @@ class StatefulOperator {
 
   std::unique_ptr<exec::Operator> operator_;
   std::vector<std::unique_ptr<StatefulOperator>> targets_;
-  bool sink;
+  bool sink_;
   bool sourceEmpty_ = true;
   std::unique_ptr<CombinedWatermarkStatus> combinedWatermarkStatus_;
   StreamOperatorStateHandlerPtr stateHandler_;

--- a/velox/experimental/stateful/StatefulOperator.h
+++ b/velox/experimental/stateful/StatefulOperator.h
@@ -56,10 +56,10 @@ class StatefulOperator {
 
   virtual bool isFinished();
 
-  // Receives a StreamRecord and feeds value() to the underlying velox operator.
-  // The base implementation drops rowKind, which is correct for stateless
-  // passthrough. Operators with retract semantics (group aggregation, stream
-  // join, etc.) must override this and advance() to act on rowKind.
+  // Receives a StreamRecord and feeds record() to the underlying velox
+  // operator. The base implementation drops rowKind, which is correct for
+  // stateless passthrough. Operators with retract semantics (group aggregation,
+  // stream join, etc.) must override this and advance() to act on rowKind.
   virtual void addInput(StreamElementPtr input);
 
   // Pulls the next output batch from the underlying velox operator and wraps it

--- a/velox/experimental/stateful/StatefulPlanner.cpp
+++ b/velox/experimental/stateful/StatefulPlanner.cpp
@@ -45,6 +45,7 @@
 #include "velox/experimental/stateful/KeySelector.h"
 #include "velox/experimental/stateful/LocalWindowAggregator.h"
 #include "velox/experimental/stateful/StatefulPlanNode.h"
+#include "velox/experimental/stateful/StatefulSourceOperator.h"
 #include "velox/experimental/stateful/StreamJoin.h"
 #include "velox/experimental/stateful/StreamKeyedOperator.h"
 #include "velox/experimental/stateful/StreamPartition.h"
@@ -420,6 +421,10 @@ StatefulOperatorPtr StatefulPlanner::transformGenericOperator(
         std::move(op), std::move(targets), std::move(watermarkGenerator));
   }
   std::unique_ptr<exec::Operator> op = transformOperator(planNode.node());
+  if (std::dynamic_pointer_cast<const core::TableScanNode>(planNode.node())) {
+    return std::make_unique<StatefulSourceOperator>(
+        std::move(op), std::move(targets));
+  }
   return std::make_unique<StatefulOperator>(std::move(op), std::move(targets));
 }
 

--- a/velox/experimental/stateful/StatefulSourceOperator.h
+++ b/velox/experimental/stateful/StatefulSourceOperator.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/experimental/stateful/StatefulOperator.h"
+#include "velox/experimental/stateful/StreamElement.h"
+
+namespace facebook::velox::stateful {
+
+// Wraps a source operator (TableScan, etc.) that has no upstream input.
+// StreamRecord::create splits the source RowVector: if it carries a trailing
+// $row_kind column, the result carries per-row RowKind; otherwise the result
+// is appendOnly.
+class StatefulSourceOperator : public StatefulOperator {
+ public:
+  using StatefulOperator::StatefulOperator;
+
+  // Sources never receive input from upstream. Reject loudly to catch wiring
+  // bugs in the operator chain.
+  void addInput(StreamElementPtr /*input*/) final {
+    VELOX_FAIL("StatefulSourceOperator does not support addInput");
+  }
+
+  void advance() override {
+    setSourceEmpty(true);
+    auto intermediateResult = op()->getOutput();
+    if (!intermediateResult) {
+      return;
+    }
+    setSourceEmpty(false);
+    pushOutput(
+        StreamRecord::create(getPlanNodeId(), std::move(intermediateResult)));
+  }
+};
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/StreamElement.cpp
+++ b/velox/experimental/stateful/StreamElement.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/stateful/StreamElement.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/experimental/stateful/RowKind.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ConstantVector.h"
+
+namespace facebook::velox::stateful {
+
+RowVectorPtr StreamRecord::toMergedRowVector(bool alwaysAppendRowKind) const {
+  if (appendOnly() && !alwaysAppendRowKind) {
+    return record_;
+  }
+  auto rowType = asRowType(record_->type());
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  std::vector<VectorPtr> children;
+  auto n = rowType->size();
+  names.reserve(n + 1);
+  types.reserve(n + 1);
+  children.reserve(n + 1);
+  for (size_t i = 0; i < n; ++i) {
+    names.emplace_back(rowType->nameOf(i));
+    types.emplace_back(rowType->childAt(i));
+    children.emplace_back(record_->childAt(i));
+  }
+  names.emplace_back(kRowKindColumnName);
+  types.emplace_back(TINYINT());
+  if (appendOnly()) {
+    children.emplace_back(std::make_shared<ConstantVector<int8_t>>(
+        record_->pool(),
+        size(),
+        false /*isNull*/,
+        TINYINT(),
+        static_cast<int8_t>(RowKind::INSERT)));
+  } else {
+    children.emplace_back(rowKind_);
+  }
+  auto mergedType = ROW(std::move(names), std::move(types));
+  return std::make_shared<RowVector>(
+      record_->pool(), mergedType, nullptr, size(), std::move(children));
+}
+
+std::shared_ptr<StreamRecord> StreamRecord::create(
+    std::string nodeId,
+    RowVectorPtr merged) {
+  VELOX_USER_CHECK_NOT_NULL(merged, "merged RowVector must not be null");
+  auto rowType = asRowType(merged->type());
+  if (rowType->size() == 0 ||
+      rowType->nameOf(rowType->size() - 1) != kRowKindColumnName) {
+    return std::make_shared<StreamRecord>(std::move(nodeId), std::move(merged));
+  }
+  auto lastIdx = rowType->size() - 1;
+  auto kindVector = merged->childAt(lastIdx);
+  auto simpleKind = std::dynamic_pointer_cast<SimpleVector<int8_t>>(kindVector);
+  VELOX_USER_CHECK_NOT_NULL(
+      simpleKind,
+      "$row_kind column must be a SimpleVector<int8_t>, got encoding: {}",
+      kindVector->encoding());
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  std::vector<VectorPtr> children;
+  names.reserve(lastIdx);
+  types.reserve(lastIdx);
+  children.reserve(lastIdx);
+  for (size_t i = 0; i < lastIdx; ++i) {
+    names.emplace_back(rowType->nameOf(i));
+    types.emplace_back(rowType->childAt(i));
+    children.emplace_back(merged->childAt(i));
+  }
+  auto valueType = ROW(std::move(names), std::move(types));
+  auto value = std::make_shared<RowVector>(
+      merged->pool(), valueType, nullptr, merged->size(), std::move(children));
+  // Normalize a constant INSERT row kind back to appendOnly (rowKind=null) so
+  // downstream code can rely on appendOnly() without re-checking the encoding.
+  if (simpleKind->isConstantEncoding() &&
+      simpleKind->as<ConstantVector<int8_t>>()->valueAt(0) ==
+          static_cast<int8_t>(RowKind::INSERT)) {
+    return std::make_shared<StreamRecord>(std::move(nodeId), std::move(value));
+  }
+  return std::make_shared<StreamRecord>(
+      std::move(nodeId), std::move(value), std::move(simpleKind));
+}
+
+} // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/StreamElement.cpp
+++ b/velox/experimental/stateful/StreamElement.cpp
@@ -53,7 +53,11 @@ RowVectorPtr StreamRecord::toMergedRowVector(bool alwaysAppendRowKind) const {
   }
   auto mergedType = ROW(std::move(names), std::move(types));
   return std::make_shared<RowVector>(
-      record_->pool(), mergedType, nullptr, size(), std::move(children));
+      record_->pool(),
+      mergedType,
+      record_->nulls(),
+      size(),
+      std::move(children));
 }
 
 std::shared_ptr<StreamRecord> StreamRecord::create(
@@ -67,11 +71,24 @@ std::shared_ptr<StreamRecord> StreamRecord::create(
   }
   auto lastIdx = rowType->size() - 1;
   auto kindVector = merged->childAt(lastIdx);
+  VELOX_USER_CHECK_EQ(
+      kindVector->type()->kind(),
+      TypeKind::TINYINT,
+      "$row_kind column must be TINYINT, got {}",
+      kindVector->type()->toString());
   auto simpleKind = std::dynamic_pointer_cast<SimpleVector<int8_t>>(kindVector);
   VELOX_USER_CHECK_NOT_NULL(
       simpleKind,
       "$row_kind column must be a SimpleVector<int8_t>, got encoding: {}",
       kindVector->encoding());
+  VELOX_USER_CHECK_EQ(
+      simpleKind->size(),
+      merged->size(),
+      "$row_kind column length {} does not match merged RowVector length {}",
+      simpleKind->size(),
+      merged->size());
+  VELOX_USER_CHECK(
+      !simpleKind->mayHaveNulls(), "$row_kind column must not contain nulls");
   std::vector<std::string> names;
   std::vector<TypePtr> types;
   std::vector<VectorPtr> children;
@@ -85,9 +102,20 @@ std::shared_ptr<StreamRecord> StreamRecord::create(
   }
   auto valueType = ROW(std::move(names), std::move(types));
   auto value = std::make_shared<RowVector>(
-      merged->pool(), valueType, nullptr, merged->size(), std::move(children));
+      merged->pool(),
+      valueType,
+      merged->nulls(),
+      merged->size(),
+      std::move(children));
   // Normalize a constant INSERT row kind back to appendOnly (rowKind=null) so
   // downstream code can rely on appendOnly() without re-checking the encoding.
+  // Only ConstantVector is normalized here: its single shared value is O(1)
+  // to inspect. Every other SimpleVector<int8_t> encoding (FlatVector,
+  // DictionaryVector, SequenceVector, ...) would require an O(n) scan over
+  // per-row kind bytes to detect all-INSERT, which is too expensive on the
+  // create() hot path. Such records keep a non-null rowKind_ and appendOnly()
+  // returns false; downstream consumers must walk per-row kinds themselves
+  // (semantically correct, just on the slow path).
   if (simpleKind->isConstantEncoding() &&
       simpleKind->as<ConstantVector<int8_t>>()->valueAt(0) ==
           static_cast<int8_t>(RowKind::INSERT)) {

--- a/velox/experimental/stateful/StreamElement.h
+++ b/velox/experimental/stateful/StreamElement.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 
 #include "velox/core/PlanNode.h"
+#include "velox/vector/SimpleVector.h"
 
 namespace facebook::velox::stateful {
 
@@ -82,31 +83,74 @@ class WatermarkStatus : public StreamElement {
   const bool idle_;
 };
 
+// StreamRecord carries a RowVector of user columns together with an optional
+// per-row RowKind vector (TINYINT, byte ordinals matching Flink RowKind:
+// 0=INSERT, 1=UPDATE_BEFORE, 2=UPDATE_AFTER, 3=DELETE). When rowKind is null
+// the record is appendOnly (all INSERT) and toMergedRowVector() returns the
+// user RowVector without a trailing $row_kind column.
 class StreamRecord : public StreamElement {
  public:
-  StreamRecord(std::string nodeId, RowVectorPtr record)
+  // Primary constructors: user RowVector + optional per-row RowKind vector.
+  // rowKind == nullptr means appendOnly.
+  StreamRecord(
+      std::string nodeId,
+      RowVectorPtr record,
+      SimpleVectorPtr<int8_t> rowKind = nullptr)
       : StreamElement(nodeId),
         record_(std::move(record)),
+        rowKind_(std::move(rowKind)),
         timestamp_(-1),
         hasTimestamp_(false),
         key_(-1) {}
 
-  StreamRecord(std::string nodeId, RowVectorPtr record, int64_t timestamp)
+  StreamRecord(
+      std::string nodeId,
+      RowVectorPtr record,
+      SimpleVectorPtr<int8_t> rowKind,
+      int64_t timestamp)
       : StreamElement(nodeId),
         record_(std::move(record)),
+        rowKind_(std::move(rowKind)),
         timestamp_(timestamp),
         hasTimestamp_(true),
         key_(-1) {}
 
-  StreamRecord(std::string nodeId, int key, RowVectorPtr record)
+  // Convenience constructor for appendOnly records carrying a timestamp.
+  StreamRecord(std::string nodeId, RowVectorPtr record, int64_t timestamp)
       : StreamElement(nodeId),
         record_(std::move(record)),
+        rowKind_(nullptr),
+        timestamp_(timestamp),
+        hasTimestamp_(true),
+        key_(-1) {}
+
+  StreamRecord(
+      std::string nodeId,
+      int key,
+      RowVectorPtr record,
+      SimpleVectorPtr<int8_t> rowKind = nullptr)
+      : StreamElement(nodeId),
+        record_(std::move(record)),
+        rowKind_(std::move(rowKind)),
         timestamp_(-1),
         hasTimestamp_(false),
         key_(key) {}
 
   const RowVectorPtr& record() const {
     return record_;
+  }
+
+  // May be null when appendOnly.
+  const SimpleVectorPtr<int8_t>& rowKind() const {
+    return rowKind_;
+  }
+
+  bool appendOnly() const {
+    return !rowKind_;
+  }
+
+  vector_size_t size() const {
+    return record_->size();
   }
 
   int64_t timestamp() const {
@@ -125,10 +169,30 @@ class StreamRecord : public StreamElement {
     return hasTimestamp_;
   }
 
+  // Merges record_ + rowKind_ into a single RowVector. By default an appendOnly
+  // record returns record_ as-is (no trailing $row_kind column). When
+  // alwaysAppendRowKind is true, the trailing $row_kind column is always
+  // present: rowKind_ for changelog records, or a ConstantVector<int8_t>
+  // (INSERT) for appendOnly records. Used by callers (e.g. JNI boundary,
+  // StatefulCalcOperator) that need a RowVector schema matching an
+  // N+1-column output type regardless of appendOnly state.
+  RowVectorPtr toMergedRowVector(bool alwaysAppendRowKind = false) const;
+
+  // Splits a merged RowVector (user columns + optional trailing $row_kind)
+  // back into a StreamRecord. If the trailing column is absent or is a
+  // ConstantVector<int8_t>(INSERT), the result is appendOnly (rowKind=null).
+  static std::shared_ptr<StreamRecord> create(
+      std::string nodeId,
+      RowVectorPtr merged);
+
  private:
   const RowVectorPtr record_;
+  const SimpleVectorPtr<int8_t> rowKind_;
   const int64_t timestamp_;
   bool hasTimestamp_ = false;
   const int key_;
 };
+
+using StreamRecordPtr = std::shared_ptr<StreamRecord>;
+
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/StreamKeyedOperator.cpp
+++ b/velox/experimental/stateful/StreamKeyedOperator.cpp
@@ -42,6 +42,7 @@ bool StreamKeyedOperator::isFinished() {
 void StreamKeyedOperator::addInput(StreamElementPtr input) {
   VELOX_CHECK_NULL(input_);
   auto record = std::static_pointer_cast<StreamRecord>(input);
+  // TODO: preserve rowKind across this operator.
   input_ = record->record();
 }
 

--- a/velox/experimental/stateful/StreamPartition.cpp
+++ b/velox/experimental/stateful/StreamPartition.cpp
@@ -37,23 +37,27 @@ bool StreamPartition::isFinished() {
 }
 
 void StreamPartition::addInput(StreamElementPtr input) {
-  VELOX_CHECK_NULL(input_);
+  VELOX_CHECK_NULL(inputRowVector_);
+  VELOX_CHECK_NULL(inputRowKind_);
   auto record = std::static_pointer_cast<StreamRecord>(input);
-  input_ = record->record();
+  inputRowVector_ = record->record();
+  inputRowKind_ = record->rowKind();
 }
 
 void StreamPartition::advance() {
-  prepareForInput(input_);
+  prepareForInput(inputRowVector_);
 
   if (numPartitions_ == 1) {
-    pushToTask(std::make_shared<StreamRecord>(getPlanNodeId(), 0, input_));
-    input_.reset();
+    pushToTask(std::make_shared<StreamRecord>(
+        getPlanNodeId(), 0, inputRowVector_, inputRowKind_));
+    inputRowVector_.reset();
+    inputRowKind_.reset();
     return;
   }
 
   // TODO: The partition function doesn't use max parallelism.
-  partitionFunction_->partition(*input_, partitions_);
-  const auto numInput = input_->size();
+  partitionFunction_->partition(*inputRowVector_, partitions_);
+  const auto numInput = inputRowVector_->size();
   std::vector<vector_size_t> maxIndex(numPartitions_, 0);
   for (auto i = 0; i < numInput; ++i) {
     ++maxIndex[partitions_[i]];
@@ -67,18 +71,19 @@ void StreamPartition::advance() {
     ++maxIndex[partition];
   }
 
-  const int64_t totalSize = input_->retainedSize();
   for (auto i = 0; i < numPartitions_; i++) {
     auto partitionSize = maxIndex[i];
     if (partitionSize == 0) {
       // Do not enqueue empty partitions.
       continue;
     }
-    auto partitionData = wrapChildren(input_, partitionSize, indexBuffers_[i]);
-    pushToTask(
-        std::make_shared<StreamRecord>(getPlanNodeId(), i, partitionData));
+    auto [value, rowKind] = wrapForPartition(
+        inputRowVector_, inputRowKind_, partitionSize, indexBuffers_[i]);
+    pushToTask(std::make_shared<StreamRecord>(
+        getPlanNodeId(), i, std::move(value), std::move(rowKind)));
   }
-  input_.reset();
+  inputRowVector_.reset();
+  inputRowKind_.reset();
 }
 
 void StreamPartition::pushToTask(StreamElementPtr output) {
@@ -87,8 +92,7 @@ void StreamPartition::pushToTask(StreamElementPtr output) {
   task->addOutput(std::move(output));
 }
 
-// These methods are copied from LocalPartition.cpp, maybe we can refactor
-// them to reuse the code in LocalPartition.cpp.
+// prepareForInput and allocateIndexBuffers are adapted from LocalPartition.cpp.
 void StreamPartition::prepareForInput(RowVectorPtr& input) {
   // Lazy vectors must be loaded or processed to ensure the late materialized in
   // order.
@@ -116,32 +120,35 @@ void StreamPartition::allocateIndexBuffers(
   }
 }
 
-RowVectorPtr StreamPartition::wrapChildren(
-    const RowVectorPtr& input,
+std::pair<RowVectorPtr, SimpleVectorPtr<int8_t>>
+StreamPartition::wrapForPartition(
+    const RowVectorPtr& value,
+    const SimpleVectorPtr<int8_t>& rowKind,
     vector_size_t size,
     const BufferPtr& indices) {
-  RowVectorPtr result = std::make_shared<RowVector>(
+  RowVectorPtr wrappedValue = std::make_shared<RowVector>(
       op()->pool(),
-      input->type(),
+      value->type(),
       nullptr,
       size,
-      std::vector<VectorPtr>(input->childrenSize()));
+      std::vector<VectorPtr>(value->childrenSize()));
+  for (auto i = 0; i < value->childrenSize(); ++i) {
+    wrappedValue->childAt(i) =
+        BaseVector::wrapInDictionary(nullptr, indices, size, value->childAt(i));
+  }
+  wrappedValue->updateContainsLazyNotLoaded();
 
-  for (auto i = 0; i < input->childrenSize(); ++i) {
-    auto& child = result->childAt(i);
-    if (child && child->encoding() == VectorEncoding::Simple::DICTIONARY &&
-        child.use_count() == 1) {
-      child->BaseVector::resize(size);
-      child->setWrapInfo(indices);
-      child->setValueVector(input->childAt(i));
-    } else {
-      child = BaseVector::wrapInDictionary(
-          nullptr, indices, size, input->childAt(i));
-    }
+  if (rowKind == nullptr) {
+    return {std::move(wrappedValue), nullptr};
   }
 
-  result->updateContainsLazyNotLoaded();
-  return result;
+  // Re-apply the same indices to rowKind so each partition carries the original
+  // row kind for its rows. wrapInDictionary may return a DictionaryVector or,
+  // for constant input, a ConstantVector; both inherit from SimpleVector.
+  auto wrapped = BaseVector::wrapInDictionary(nullptr, indices, size, rowKind);
+  auto wrappedRowKind =
+      std::dynamic_pointer_cast<SimpleVector<int8_t>>(wrapped);
+  return {std::move(wrappedValue), std::move(wrappedRowKind)};
 }
 
 } // namespace facebook::velox::stateful

--- a/velox/experimental/stateful/StreamPartition.cpp
+++ b/velox/experimental/stateful/StreamPartition.cpp
@@ -16,6 +16,7 @@
 #include "velox/experimental/stateful/StreamPartition.h"
 #include <cstdint>
 #include "velox/experimental/stateful/StatefulTask.h"
+#include "velox/vector/VectorEncoding.h"
 
 namespace facebook::velox::stateful {
 
@@ -25,7 +26,7 @@ StreamPartition::StreamPartition(
     int numPartitions)
     : StatefulOperator(std::move(op), {}),
       partitionFunction_(std::move(partitionFunctionSpec.create(
-          numPartitions_,
+          numPartitions,
           /*localExchange=*/false))),
       numPartitions_(numPartitions) {
   indexBuffers_.resize(numPartitions_);
@@ -148,6 +149,12 @@ StreamPartition::wrapForPartition(
   auto wrapped = BaseVector::wrapInDictionary(nullptr, indices, size, rowKind);
   auto wrappedRowKind =
       std::dynamic_pointer_cast<SimpleVector<int8_t>>(wrapped);
+  VELOX_CHECK_NOT_NULL(
+      wrappedRowKind,
+      "wrapInDictionary unexpectedly returned a non-SimpleVector encoding for the rowKind column: {}",
+      wrapped == nullptr
+          ? std::string{"null"}
+          : VectorEncoding::mapSimpleToName(wrapped->encoding()));
   return {std::move(wrappedValue), std::move(wrappedRowKind)};
 }
 

--- a/velox/experimental/stateful/StreamPartition.h
+++ b/velox/experimental/stateful/StreamPartition.h
@@ -45,15 +45,21 @@ class StreamPartition : public StatefulOperator {
 
   void allocateIndexBuffers(const std::vector<vector_size_t>& sizes);
 
-  RowVectorPtr wrapChildren(
-      const RowVectorPtr& input,
+  // Applies partition indices to a (value, rowKind) pair: wraps each child
+  // column of value and (when present) the rowKind vector with the same
+  // dictionary. appendOnly inputs (rowKind == nullptr) produce appendOnly
+  // outputs.
+  std::pair<RowVectorPtr, SimpleVectorPtr<int8_t>> wrapForPartition(
+      const RowVectorPtr& value,
+      const SimpleVectorPtr<int8_t>& rowKind,
       vector_size_t size,
       const BufferPtr& indices);
 
   const std::unique_ptr<core::PartitionFunction> partitionFunction_;
   const int numPartitions_;
 
-  RowVectorPtr input_;
+  RowVectorPtr inputRowVector_;
+  SimpleVectorPtr<int8_t> inputRowKind_;
 
   /// Reusable memory for hash calculation.
   std::vector<uint32_t> partitions_;

--- a/velox/experimental/stateful/WatermarkAssigner.cpp
+++ b/velox/experimental/stateful/WatermarkAssigner.cpp
@@ -37,6 +37,7 @@ WatermarkAssigner::~WatermarkAssigner() {
 
 void WatermarkAssigner::addInput(StreamElementPtr input) {
   auto record = std::static_pointer_cast<StreamRecord>(input);
+  // TODO: preserve rowKind across this operator.
   input_ = record->record();
   op()->addInput(input_);
 

--- a/velox/experimental/stateful/WatermarkSource.cpp
+++ b/velox/experimental/stateful/WatermarkSource.cpp
@@ -45,8 +45,7 @@ void WatermarkSource::advance() {
   }
 
   setSourceEmpty(false);
-  pushOutput(
-      std::make_shared<StreamRecord>(getPlanNodeId(), intermediateResult));
+  pushOutput(StreamRecord::create(getPlanNodeId(), intermediateResult));
 
   if (intermediateResult->size() == 0) {
     return;

--- a/velox/experimental/stateful/WindowAggregator.cpp
+++ b/velox/experimental/stateful/WindowAggregator.cpp
@@ -65,6 +65,7 @@ void WindowAggregator::initializeState() {
 void WindowAggregator::addInput(StreamElementPtr input) {
   VELOX_CHECK(!input_, "Last input has not been processed");
   auto record = std::static_pointer_cast<StreamRecord>(input);
+  // TODO: preserve rowKind across this operator.
   input_ = record->record();
 }
 

--- a/velox/experimental/stateful/tests/CMakeLists.txt
+++ b/velox/experimental/stateful/tests/CMakeLists.txt
@@ -26,6 +26,10 @@ add_executable(velox_stateful_idle_timer_manager_test IdleTimerManagerTest.cpp)
 add_executable(velox_stateful_source_operator_test
                StatefulSourceOperatorTest.cpp)
 
+add_executable(velox_stateful_stream_partition_test StreamPartitionTest.cpp)
+
+add_executable(velox_stateful_stream_record_test StreamRecordTest.cpp)
+
 add_test(velox_stateful_watermark_generator_test
          velox_stateful_watermark_generator_test)
 
@@ -40,6 +44,11 @@ add_test(velox_stateful_idle_timer_manager_test
 
 add_test(velox_stateful_source_operator_test
          velox_stateful_source_operator_test)
+
+add_test(velox_stateful_stream_partition_test
+         velox_stateful_stream_partition_test)
+
+add_test(velox_stateful_stream_record_test velox_stateful_stream_record_test)
 
 target_link_libraries(
   velox_stateful_combined_watermark_status_test velox_common_base GTest::gtest
@@ -93,6 +102,26 @@ target_link_libraries(
 
 target_link_libraries(
   velox_stateful_source_operator_test
+  velox_stateful_exec
+  velox_vector_test_lib
+  velox_exec_test_lib
+  velox_exec
+  velox_common_base
+  GTest::gtest
+  GTest::gtest_main)
+
+target_link_libraries(
+  velox_stateful_stream_partition_test
+  velox_stateful_exec
+  velox_vector_test_lib
+  velox_exec_test_lib
+  velox_exec
+  velox_common_base
+  GTest::gtest
+  GTest::gtest_main)
+
+target_link_libraries(
+  velox_stateful_stream_record_test
   velox_stateful_exec
   velox_vector_test_lib
   velox_exec_test_lib

--- a/velox/experimental/stateful/tests/CMakeLists.txt
+++ b/velox/experimental/stateful/tests/CMakeLists.txt
@@ -23,6 +23,9 @@ add_executable(velox_stateful_watermark_idle_tracker_test
 
 add_executable(velox_stateful_idle_timer_manager_test IdleTimerManagerTest.cpp)
 
+add_executable(velox_stateful_source_operator_test
+               StatefulSourceOperatorTest.cpp)
+
 add_test(velox_stateful_watermark_generator_test
          velox_stateful_watermark_generator_test)
 
@@ -34,6 +37,9 @@ add_test(velox_stateful_watermark_idle_tracker_test
 
 add_test(velox_stateful_idle_timer_manager_test
          velox_stateful_idle_timer_manager_test)
+
+add_test(velox_stateful_source_operator_test
+         velox_stateful_source_operator_test)
 
 target_link_libraries(
   velox_stateful_combined_watermark_status_test velox_common_base GTest::gtest
@@ -78,6 +84,16 @@ target_link_libraries(
   velox_stateful_state
   velox_stateful_window
   velox_stateful_udf
+  velox_vector_test_lib
+  velox_exec_test_lib
+  velox_exec
+  velox_common_base
+  GTest::gtest
+  GTest::gtest_main)
+
+target_link_libraries(
+  velox_stateful_source_operator_test
+  velox_stateful_exec
   velox_vector_test_lib
   velox_exec_test_lib
   velox_exec

--- a/velox/experimental/stateful/tests/StatefulSourceOperatorTest.cpp
+++ b/velox/experimental/stateful/tests/StatefulSourceOperatorTest.cpp
@@ -21,12 +21,13 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/PlanFragment.h"
+#include "velox/core/PlanNode.h"
 #include "velox/exec/Driver.h"
-#include "velox/exec/Task.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/experimental/stateful/RowKind.h"
 #include "velox/experimental/stateful/StatefulOperator.h"
+#include "velox/experimental/stateful/StatefulTask.h"
 #include "velox/experimental/stateful/StreamElement.h"
 
 namespace facebook::velox::stateful::test {
@@ -133,12 +134,10 @@ class StatefulSourceOperatorTest : public exec::test::OperatorTestBase {
     planFragment.planNode = std::make_shared<core::ValuesNode>(
         core::PlanNodeId{"values"}, std::vector<RowVectorPtr>{plainBatch()});
     executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(1);
-    task_ = exec::Task::create(
+    task_ = StatefulTask::create(
         "StatefulSourceOperatorTest_task",
         std::move(planFragment),
-        0,
-        core::QueryCtx::create(executor_.get()),
-        exec::Task::ExecutionMode::kParallel);
+        core::QueryCtx::create(executor_.get()));
     driver_ = exec::Driver::testingCreate();
     driverCtx_ = std::make_unique<exec::DriverCtx>(task_, 0, 0, 0, 0);
     driverCtx_->driver = driver_.get();
@@ -163,7 +162,7 @@ class StatefulSourceOperatorTest : public exec::test::OperatorTestBase {
   }
 
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
-  std::shared_ptr<exec::Task> task_;
+  std::shared_ptr<StatefulTask> task_;
   std::shared_ptr<exec::Driver> driver_;
   std::unique_ptr<exec::DriverCtx> driverCtx_;
 };

--- a/velox/experimental/stateful/tests/StatefulSourceOperatorTest.cpp
+++ b/velox/experimental/stateful/tests/StatefulSourceOperatorTest.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/stateful/StatefulSourceOperator.h"
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/PlanFragment.h"
+#include "velox/exec/Driver.h"
+#include "velox/exec/Task.h"
+#include "velox/exec/Values.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/experimental/stateful/RowKind.h"
+#include "velox/experimental/stateful/StatefulOperator.h"
+#include "velox/experimental/stateful/StreamElement.h"
+
+namespace facebook::velox::stateful::test {
+namespace {
+
+class PresetOutputOperator : public exec::Operator {
+ public:
+  PresetOutputOperator(
+      exec::DriverCtx* driverCtx,
+      std::vector<RowVectorPtr> outputs,
+      std::string planNodeId = "preset_output")
+      : Operator(
+            driverCtx,
+            outputs.empty() ? ROW({"c"}, {BIGINT()})
+                            : asRowType(outputs[0]->type()),
+            0,
+            std::move(planNodeId),
+            "PresetOutput"),
+        outputs_(std::move(outputs)) {}
+
+  bool needsInput() const override {
+    return false;
+  }
+
+  void addInput(RowVectorPtr) override {}
+
+  RowVectorPtr getOutput() override {
+    if (nextOutput_ >= outputs_.size()) {
+      return nullptr;
+    }
+    return outputs_[nextOutput_++];
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture*) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return nextOutput_ >= outputs_.size();
+  }
+
+ private:
+  std::vector<RowVectorPtr> outputs_;
+  size_t nextOutput_{0};
+};
+
+class NoOutputOperator : public exec::Operator {
+ public:
+  explicit NoOutputOperator(exec::DriverCtx* driverCtx)
+      : Operator(
+            driverCtx,
+            ROW({"c"}, {BIGINT()}),
+            0,
+            "spy_target",
+            "SpyTarget") {}
+
+  bool needsInput() const override {
+    return true;
+  }
+
+  void addInput(RowVectorPtr) override {}
+
+  RowVectorPtr getOutput() override {
+    return nullptr;
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture*) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return false;
+  }
+};
+
+class CaptureTarget : public StatefulOperator {
+ public:
+  explicit CaptureTarget(exec::DriverCtx* driverCtx)
+      : StatefulOperator(std::make_unique<NoOutputOperator>(driverCtx), {}) {}
+
+  void addInput(StreamElementPtr input) override {
+    lastInput_ = std::move(input);
+  }
+
+  void advance() override {}
+
+  StreamRecord* lastRecord() const {
+    if (!lastInput_ || !lastInput_->isRecord()) {
+      return nullptr;
+    }
+    return std::static_pointer_cast<StreamRecord>(lastInput_).get();
+  }
+
+ private:
+  StreamElementPtr lastInput_;
+};
+
+class StatefulSourceOperatorTest : public exec::test::OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+
+    core::PlanFragment planFragment;
+    planFragment.planNode = std::make_shared<core::ValuesNode>(
+        core::PlanNodeId{"values"}, std::vector<RowVectorPtr>{plainBatch()});
+    executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(1);
+    task_ = exec::Task::create(
+        "StatefulSourceOperatorTest_task",
+        std::move(planFragment),
+        0,
+        core::QueryCtx::create(executor_.get()),
+        exec::Task::ExecutionMode::kParallel);
+    driver_ = exec::Driver::testingCreate();
+    driverCtx_ = std::make_unique<exec::DriverCtx>(task_, 0, 0, 0, 0);
+    driverCtx_->driver = driver_.get();
+  }
+
+  void TearDown() override {
+    driverCtx_.reset();
+    driver_.reset();
+    task_.reset();
+    executor_.reset();
+    OperatorTestBase::TearDown();
+  }
+
+  RowVectorPtr plainBatch() {
+    return makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
+  }
+
+  RowVectorPtr mergedBatch() {
+    auto value = makeFlatVector<int64_t>({10, 20, 30, 40});
+    auto rowKind = makeFlatVector<int8_t>({0, 1, 2, 3});
+    return makeRowVector({"c", "$row_kind"}, {value, rowKind});
+  }
+
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+  std::shared_ptr<exec::Task> task_;
+  std::shared_ptr<exec::Driver> driver_;
+  std::unique_ptr<exec::DriverCtx> driverCtx_;
+};
+
+TEST_F(StatefulSourceOperatorTest, rejectsAddInput) {
+  StatefulSourceOperator sourceOp(
+      std::make_unique<PresetOutputOperator>(
+          driverCtx_.get(), std::vector<RowVectorPtr>{plainBatch()}),
+      {});
+
+  VELOX_ASSERT_THROW(
+      sourceOp.addInput(std::make_shared<StreamRecord>("source", plainBatch())),
+      "StatefulSourceOperator does not support addInput");
+}
+
+TEST_F(StatefulSourceOperatorTest, advanceWrapsPlainRowVectorAsAppendOnly) {
+  auto capture = std::make_unique<CaptureTarget>(driverCtx_.get());
+  auto* capturePtr = capture.get();
+  std::vector<StatefulOperatorPtr> targets;
+  targets.push_back(std::move(capture));
+
+  StatefulSourceOperator sourceOp(
+      std::make_unique<PresetOutputOperator>(
+          driverCtx_.get(), std::vector<RowVectorPtr>{plainBatch()}),
+      std::move(targets));
+
+  EXPECT_TRUE(sourceOp.sourceEmpty());
+  sourceOp.advance();
+  EXPECT_FALSE(sourceOp.sourceEmpty());
+
+  auto* record = capturePtr->lastRecord();
+  ASSERT_NE(record, nullptr);
+  EXPECT_TRUE(record->appendOnly());
+  EXPECT_EQ(record->rowKind(), nullptr);
+  EXPECT_EQ(record->size(), 3);
+}
+
+TEST_F(StatefulSourceOperatorTest, advanceSplitsMergedRowVector) {
+  auto capture = std::make_unique<CaptureTarget>(driverCtx_.get());
+  auto* capturePtr = capture.get();
+  std::vector<StatefulOperatorPtr> targets;
+  targets.push_back(std::move(capture));
+
+  StatefulSourceOperator sourceOp(
+      std::make_unique<PresetOutputOperator>(
+          driverCtx_.get(), std::vector<RowVectorPtr>{mergedBatch()}),
+      std::move(targets));
+
+  sourceOp.advance();
+
+  auto* record = capturePtr->lastRecord();
+  ASSERT_NE(record, nullptr);
+  EXPECT_FALSE(record->appendOnly());
+  ASSERT_NE(record->rowKind(), nullptr);
+  EXPECT_EQ(
+      record->rowKind()->valueAt(0), static_cast<int8_t>(RowKind::INSERT));
+  EXPECT_EQ(
+      record->rowKind()->valueAt(1),
+      static_cast<int8_t>(RowKind::UPDATE_BEFORE));
+  EXPECT_EQ(
+      record->rowKind()->valueAt(2),
+      static_cast<int8_t>(RowKind::UPDATE_AFTER));
+  EXPECT_EQ(
+      record->rowKind()->valueAt(3), static_cast<int8_t>(RowKind::DELETE));
+  EXPECT_EQ(record->record()->type()->size(), 1);
+}
+
+TEST_F(StatefulSourceOperatorTest, advanceTracksSourceEmpty) {
+  auto capture = std::make_unique<CaptureTarget>(driverCtx_.get());
+  std::vector<StatefulOperatorPtr> targets;
+  targets.push_back(std::move(capture));
+
+  StatefulSourceOperator sourceOp(
+      std::make_unique<PresetOutputOperator>(
+          driverCtx_.get(), std::vector<RowVectorPtr>{plainBatch()}),
+      std::move(targets));
+
+  EXPECT_TRUE(sourceOp.sourceEmpty());
+  sourceOp.advance();
+  EXPECT_FALSE(sourceOp.sourceEmpty());
+  sourceOp.advance();
+  EXPECT_TRUE(sourceOp.sourceEmpty());
+}
+
+} // namespace
+} // namespace facebook::velox::stateful::test
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return RUN_ALL_TESTS();
+}

--- a/velox/experimental/stateful/tests/StreamPartitionTest.cpp
+++ b/velox/experimental/stateful/tests/StreamPartitionTest.cpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/stateful/StreamPartition.h"
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "velox/core/PlanFragment.h"
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Driver.h"
+#include "velox/exec/Values.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/experimental/stateful/RowKind.h"
+#include "velox/experimental/stateful/StatefulTask.h"
+#include "velox/experimental/stateful/StreamElement.h"
+
+namespace facebook::velox::stateful::test {
+namespace {
+
+class NoOutputOperator : public exec::Operator {
+ public:
+  explicit NoOutputOperator(exec::DriverCtx* driverCtx)
+      : Operator(
+            driverCtx,
+            ROW({"c"}, {BIGINT()}),
+            0,
+            "spy_target",
+            "SpyTarget") {}
+
+  bool needsInput() const override {
+    return true;
+  }
+
+  void addInput(RowVectorPtr) override {}
+
+  RowVectorPtr getOutput() override {
+    return nullptr;
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture*) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return false;
+  }
+};
+
+// Assigns row i to partition (i % numPartitions). Used to get a deterministic
+// split across partitions without depending on hash internals.
+class RowModPartitionFunction : public core::PartitionFunction {
+ public:
+  explicit RowModPartitionFunction(int numPartitions)
+      : numPartitions_(numPartitions) {}
+
+  std::optional<uint32_t> partition(
+      const RowVector& input,
+      std::vector<uint32_t>& partitions) override {
+    auto size = input.size();
+    partitions.resize(size);
+    for (uint32_t i = 0; i < size; ++i) {
+      partitions[i] = i % numPartitions_;
+    }
+    return std::nullopt;
+  }
+
+ private:
+  const int numPartitions_;
+};
+
+class RowModPartitionFunctionSpec : public core::PartitionFunctionSpec {
+ public:
+  std::unique_ptr<core::PartitionFunction> create(
+      int numPartitions,
+      bool /*localExchange*/) const override {
+    return std::make_unique<RowModPartitionFunction>(numPartitions);
+  }
+
+  std::string toString() const override {
+    return "ROW_MOD";
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "RowModPartitionFunctionSpec";
+    return obj;
+  }
+
+  static core::PartitionFunctionSpecPtr deserialize(
+      const folly::dynamic& /*obj*/,
+      void* /*context*/) {
+    return std::make_shared<RowModPartitionFunctionSpec>();
+  }
+};
+
+class StreamPartitionTest : public exec::test::OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    core::PlanFragment planFragment;
+    planFragment.planNode = std::make_shared<core::ValuesNode>(
+        core::PlanNodeId{"values"}, std::vector<RowVectorPtr>{plainBatch()});
+    executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(1);
+    task_ = StatefulTask::create(
+        "StreamPartitionTest_task",
+        std::move(planFragment),
+        core::QueryCtx::create(executor_.get()));
+    driver_ = exec::Driver::testingCreate();
+    driverCtx_ = std::make_unique<exec::DriverCtx>(task_, 0, 0, 0, 0);
+    driverCtx_->driver = driver_.get();
+  }
+
+  void TearDown() override {
+    driverCtx_.reset();
+    driver_.reset();
+    task_.reset();
+    executor_.reset();
+    OperatorTestBase::TearDown();
+  }
+
+  RowVectorPtr plainBatch() {
+    return makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
+  }
+
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+  std::shared_ptr<StatefulTask> task_;
+  std::shared_ptr<exec::Driver> driver_;
+  std::unique_ptr<exec::DriverCtx> driverCtx_;
+};
+
+TEST_F(StreamPartitionTest, preservesAppendOnlyOutputs) {
+  RowModPartitionFunctionSpec spec;
+  StreamPartition partitionOp(
+      std::make_unique<NoOutputOperator>(driverCtx_.get()), spec, 2);
+
+  auto value = makeFlatVector<int64_t>({10, 20, 30, 40});
+  auto input =
+      std::make_shared<StreamRecord>("source", makeRowVector({"c"}, {value}));
+
+  partitionOp.addInput(input);
+  partitionOp.advance();
+
+  int32_t retCode;
+  auto r0 = std::static_pointer_cast<StreamRecord>(task_->next(retCode));
+  auto r1 = std::static_pointer_cast<StreamRecord>(task_->next(retCode));
+  ASSERT_NE(r0, nullptr);
+  ASSERT_NE(r1, nullptr);
+  EXPECT_TRUE(r0->appendOnly());
+  EXPECT_EQ(r0->rowKind(), nullptr);
+  EXPECT_TRUE(r1->appendOnly());
+  EXPECT_EQ(r1->rowKind(), nullptr);
+}
+
+TEST_F(StreamPartitionTest, carriesRowKindAcrossPartitions) {
+  RowModPartitionFunctionSpec spec;
+  StreamPartition partitionOp(
+      std::make_unique<NoOutputOperator>(driverCtx_.get()), spec, 2);
+
+  auto value = makeFlatVector<int64_t>({10, 20, 30, 40});
+  auto rowKind = makeFlatVector<int8_t>({0, 1, 2, 3});
+  auto input = std::make_shared<StreamRecord>(
+      "source",
+      makeRowVector({"c"}, {value}),
+      std::dynamic_pointer_cast<SimpleVector<int8_t>>(rowKind));
+
+  partitionOp.addInput(input);
+  partitionOp.advance();
+
+  int32_t retCode;
+  auto r0 = std::static_pointer_cast<StreamRecord>(task_->next(retCode));
+  auto r1 = std::static_pointer_cast<StreamRecord>(task_->next(retCode));
+  ASSERT_NE(r0, nullptr);
+  ASSERT_NE(r1, nullptr);
+  ASSERT_NE(r0->rowKind(), nullptr);
+  EXPECT_EQ(r0->size(), 2);
+  EXPECT_EQ(r0->rowKind()->valueAt(0), static_cast<int8_t>(RowKind::INSERT));
+  EXPECT_EQ(
+      r0->rowKind()->valueAt(1), static_cast<int8_t>(RowKind::UPDATE_AFTER));
+  ASSERT_NE(r1->rowKind(), nullptr);
+  EXPECT_EQ(r1->size(), 2);
+  EXPECT_EQ(
+      r1->rowKind()->valueAt(0), static_cast<int8_t>(RowKind::UPDATE_BEFORE));
+  EXPECT_EQ(r1->rowKind()->valueAt(1), static_cast<int8_t>(RowKind::DELETE));
+}
+
+} // namespace
+} // namespace facebook::velox::stateful::test
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return RUN_ALL_TESTS();
+}

--- a/velox/experimental/stateful/tests/StreamRecordTest.cpp
+++ b/velox/experimental/stateful/tests/StreamRecordTest.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/stateful/StreamElement.h"
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "velox/buffer/Buffer.h"
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/experimental/stateful/RowKind.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ConstantVector.h"
+#include "velox/vector/VectorEncoding.h"
+
+namespace facebook::velox::stateful::test {
+namespace {
+
+class StreamRecordTest : public exec::test::OperatorTestBase {
+ protected:
+  RowVectorPtr plainBatch() {
+    return makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
+  }
+
+  RowVectorPtr mergedBatch() {
+    auto value = makeFlatVector<int64_t>({10, 20, 30, 40});
+    auto rowKind = makeFlatVector<int8_t>({0, 1, 2, 3});
+    return makeRowVector({"c", "$row_kind"}, {value, rowKind});
+  }
+
+  RowVectorPtr makeMergedWithNulls(BufferPtr nulls) {
+    auto value = makeFlatVector<int64_t>({10, 20, 30, 40});
+    auto rowKind = makeFlatVector<int8_t>({0, 1, 2, 3});
+    return std::make_shared<RowVector>(
+        pool(),
+        ROW({"c", "$row_kind"}, {BIGINT(), TINYINT()}),
+        nulls,
+        4,
+        std::vector<VectorPtr>{value, rowKind});
+  }
+
+  BufferPtr makeNulls(std::vector<vector_size_t> nullRows) {
+    constexpr vector_size_t kSize = 4;
+    auto nulls = AlignedBuffer::allocate<uint64_t>(
+        bits::nwords(kSize), pool(), bits::kNotNull64);
+    for (auto idx : nullRows) {
+      bits::setNull(nulls->asMutable<uint64_t>(), idx);
+    }
+    return nulls;
+  }
+};
+
+TEST_F(StreamRecordTest, toMergedRowVectorAppendOnlyReturnsRecordAsIs) {
+  auto batch = plainBatch();
+  auto record = std::make_shared<StreamRecord>("source", batch);
+  auto merged = record->toMergedRowVector(false);
+  ASSERT_EQ(merged->type()->size(), 1);
+  EXPECT_EQ(merged.get(), batch.get());
+}
+
+TEST_F(
+    StreamRecordTest,
+    toMergedRowVectorAlwaysAppendSynthesizesConstantInsert) {
+  auto batch = plainBatch();
+  auto record = std::make_shared<StreamRecord>("source", batch);
+  auto merged = record->toMergedRowVector(true);
+  auto mergedRowType = asRowType(merged->type());
+  ASSERT_EQ(mergedRowType->size(), 2);
+  EXPECT_EQ(mergedRowType->nameOf(1), "$row_kind");
+  auto kindVec = merged->childAt(1);
+  EXPECT_EQ(kindVec->type()->kind(), TypeKind::TINYINT);
+  ASSERT_EQ(kindVec->encoding(), VectorEncoding::Simple::CONSTANT);
+  auto constantKind =
+      std::dynamic_pointer_cast<ConstantVector<int8_t>>(kindVec);
+  ASSERT_NE(constantKind, nullptr);
+  EXPECT_EQ(constantKind->valueAt(0), static_cast<int8_t>(RowKind::INSERT));
+  EXPECT_EQ(constantKind->size(), batch->size());
+}
+
+TEST_F(StreamRecordTest, toMergedRowVectorChangelogAppendsRowKindColumn) {
+  auto record = StreamRecord::create("source", mergedBatch());
+  ASSERT_FALSE(record->appendOnly());
+  ASSERT_NE(record->rowKind(), nullptr);
+
+  auto merged = record->toMergedRowVector();
+  auto mergedRowType = asRowType(merged->type());
+  ASSERT_EQ(mergedRowType->size(), 2);
+  EXPECT_EQ(mergedRowType->nameOf(1), "$row_kind");
+  auto kindVec =
+      std::dynamic_pointer_cast<SimpleVector<int8_t>>(merged->childAt(1));
+  ASSERT_NE(kindVec, nullptr);
+  EXPECT_EQ(kindVec->valueAt(0), static_cast<int8_t>(RowKind::INSERT));
+  EXPECT_EQ(kindVec->valueAt(1), static_cast<int8_t>(RowKind::UPDATE_BEFORE));
+  EXPECT_EQ(kindVec->valueAt(2), static_cast<int8_t>(RowKind::UPDATE_AFTER));
+  EXPECT_EQ(kindVec->valueAt(3), static_cast<int8_t>(RowKind::DELETE));
+}
+
+TEST_F(StreamRecordTest, createNormalizesConstantInsertToAppendOnly) {
+  auto value = makeFlatVector<int64_t>({1, 2, 3});
+  auto constantInsert =
+      makeConstant<int8_t>(static_cast<int8_t>(RowKind::INSERT), 3, TINYINT());
+  auto merged = makeRowVector({"c", "$row_kind"}, {value, constantInsert});
+
+  auto record = StreamRecord::create("source", merged);
+  EXPECT_TRUE(record->appendOnly());
+  EXPECT_EQ(record->rowKind(), nullptr);
+  EXPECT_EQ(record->record()->type()->size(), 1);
+}
+
+TEST_F(StreamRecordTest, createRejectsRowKindSizeMismatch) {
+  auto value = makeFlatVector<int64_t>({1, 2, 3});
+  auto rowKind = makeFlatVector<int8_t>({0, 1, 2, 3});
+  auto merged = makeRowVector({"c", "$row_kind"}, {value, rowKind});
+
+  VELOX_ASSERT_USER_THROW(
+      StreamRecord::create("source", merged), "$row_kind column length");
+}
+
+TEST_F(StreamRecordTest, createRejectsNonTinyIntRowKindColumn) {
+  auto value = makeFlatVector<int64_t>({1, 2, 3});
+  auto rowKind = makeFlatVector<int32_t>({0, 1, 2});
+  auto merged = makeRowVector({"c", "$row_kind"}, {value, rowKind});
+
+  VELOX_ASSERT_USER_THROW(
+      StreamRecord::create("source", merged),
+      "$row_kind column must be TINYINT");
+}
+
+TEST_F(StreamRecordTest, createRejectsNullRowKindColumn) {
+  auto value = makeFlatVector<int64_t>({1, 2, 3});
+  auto rowKind = makeNullableFlatVector<int8_t>({0, std::nullopt, 2});
+  auto merged = makeRowVector({"c", "$row_kind"}, {value, rowKind});
+
+  VELOX_ASSERT_USER_THROW(
+      StreamRecord::create("source", merged),
+      "$row_kind column must not contain nulls");
+}
+
+TEST_F(StreamRecordTest, createPreservesTopLevelNulls) {
+  auto nulls = makeNulls({1, 3});
+  auto merged = makeMergedWithNulls(nulls);
+
+  auto record = StreamRecord::create("source", merged);
+  EXPECT_EQ(record->record()->nulls(), nulls);
+  EXPECT_FALSE(record->record()->isNullAt(0));
+  EXPECT_TRUE(record->record()->isNullAt(1));
+  EXPECT_FALSE(record->record()->isNullAt(2));
+  EXPECT_TRUE(record->record()->isNullAt(3));
+}
+
+TEST_F(StreamRecordTest, toMergedRowVectorPreservesTopLevelNulls) {
+  auto nulls = makeNulls({0, 2});
+  auto record = StreamRecord::create("source", makeMergedWithNulls(nulls));
+  ASSERT_FALSE(record->appendOnly());
+
+  auto merged = record->toMergedRowVector();
+  EXPECT_EQ(merged->nulls(), nulls);
+  EXPECT_TRUE(merged->isNullAt(0));
+  EXPECT_FALSE(merged->isNullAt(1));
+  EXPECT_TRUE(merged->isNullAt(2));
+  EXPECT_FALSE(merged->isNullAt(3));
+}
+
+} // namespace
+} // namespace facebook::velox::stateful::test
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv, false);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What is the purpose of this change?

Flink RowData carries a RowKind header (+I / -U / +U / -D, byte ordinals 0/1/2/3) that distinguishes changelog records. Today the RowKind signal is dropped at the Flink→velox boundary, so every row exiting the stateful pipeline is +I regardless of the original changelog marker. This is the velox-side foundation for threading RowKind through the stateful operator chain.

## What changes are proposed in this pull request?

Lays the velox-side foundation for threading Flink `RowKind` (`+I` / `-U` / `+U` / `-D`, byte ordinals 0/1/2/3) through the `experimental/stateful` operator chain.

### Data model

RowKind lives on `StreamRecord` as an optional `SimpleVectorPtr<int8_t>` companion to the user RowVector — it does **not** enter the RowVector schema, the plan node `outputType`, or the velox core data structures. A null `rowKind` means *appendOnly* (all INSERT).

- `StreamElement.h` (`StreamRecord`):
  - Primary constructors take `RowVectorPtr + SimpleVectorPtr<int8_t>`; existing constructors that take a bare `RowVectorPtr` keep working (appendOnly).
  - `appendOnly()`, `rowKind()`, `size()` accessors.
  - `toMergedRowVector(alwaysAppendRowKind = false)` — for JNI egress. appendOnly returns the user RowVector as-is when `alwaysAppendRowKind == false`; otherwise synthesizes a `ConstantVector<int8_t>(INSERT)` trailing column.
  - `StreamRecord::create(nodeId, merged)` — for JNI ingress. Splits a merged RowVector (user columns + optional trailing `$row_kind` TINYINT) back into a `StreamRecord`. Normalizes a `ConstantVector<int8_t>(INSERT)` trailing column back to appendOnly (`rowKind = nullptr`) so downstream operators can rely on `appendOnly()` without re-checking the encoding.

- `RowKind.h`: byte ordinals matching `org.apache.flink.types.RowKind.toByteValue()`.

### Operator integration

- `StatefulOperator` base class:
  - `addInput` forwards only `record()` to the wrapped velox operator; `rowKind` lives on `StreamRecord`. The base class is the stateless passthrough default. Subclasses with retract semantics (group aggregation, stream join, rankers) override `addInput` and `advance` to consume `rowKind` and emit per-output-row `rowKind`.
  - `advance` / `finish` follow the same pattern.
- `WatermarkSource.cpp`: `advance()` now routes the source RowVector through `StreamRecord::create` so a trailing `$row_kind` column is split consistently with `StatefulSourceOperator`. Previously it called the two-argument `StreamRecord` constructor and would treat `$row_kind` as a user column.
- `StreamPartition.cpp`:
  - `wrapForPartition` re-applies the partition dictionary to the `rowKind` vector so each downstream partition carries the original row kind for its rows. appendOnly inputs (`rowKind == nullptr`) produce appendOnly outputs.
  - `VELOX_CHECK_NOT_NULL` on the `dynamic_pointer_cast<SimpleVector<int8_t>>` result so a future encoding change inside velox cannot silently degrade a changelog stream to appendOnly at partition boundaries.
- StreamRecord::create validation
  - `create()` is the boundary between the JNI side (which produces a merged RowVector) and the velox operator chain. It now fails fast on malformed input:
  - Explicit `TypeKind::TINYINT` check on the trailing `$row_kind` column (error message names the offending type rather than just the encoding).
  - `simpleKind->size() == merged->size()` length check so a malformed merged RowVector cannot silently produce a `StreamRecord` whose `rowKind_->size()` disagrees with `record_->size()`.
  - `VELOX_USER_CHECK(!simpleKind->mayHaveNulls(), ...)` non-null check.

Related design + phased plan: [support-rowkind-column-issue](https://github.com/apache/gluten/issues/12459)

## Test

New C++ unit test `velox_stateful_changelog_row_vector_test`