### PR TITLE
feat: Improve hdfs writer with disabling flush on write and enabling fast partition path

### DIFF
--- a/velox/connectors/filesystem/FileSystemConfig.cpp
+++ b/velox/connectors/filesystem/FileSystemConfig.cpp
@@ -155,6 +155,15 @@ const std::string FileSystemWriteConfig::getPartitionTimeExtractPattern() {
       kPartitionTimeExtractPattern, "");
 }
 
+const bool FileSystemWriteConfig::flushOnWrite() {
+  return checkAndGetConfigValue<bool, false>(kFlushOnWrite, false);
+}
+
+const int32_t FileSystemWriteConfig::getZstdCompressionLevel() {
+  return checkAndGetConfigValue<int32_t, false>(
+      kZstdCompressionLevel, defaultZstdCompressionLevel);
+}
+
 const common::CompressionKind FileSystemWriteConfig::getFileCompressionType() {
   std::string compression = checkAndGetConfigValue<std::string, false>(
       kParquetCompressionCodec,

--- a/velox/connectors/filesystem/FileSystemConfig.cpp
+++ b/velox/connectors/filesystem/FileSystemConfig.cpp
@@ -176,7 +176,9 @@ const common::CompressionKind FileSystemWriteConfig::getFileCompressionType() {
   VELOX_USER_CHECK(
       compressionKind == common::CompressionKind_SNAPPY ||
           compressionKind == common::CompressionKind_LZ4 ||
-          compressionKind == common::CompressionKind_ZSTD,
+          compressionKind == common::CompressionKind_ZSTD ||
+          compressionKind == common::CompressionKind_GZIP ||
+          compressionKind == common::CompressionKind_ZLIB,
       "Unsupported parquet compression codec '{}'. Supported values are none, snappy, lz4 and zstd.",
       compression);
   return compressionKind;

--- a/velox/connectors/filesystem/FileSystemConfig.cpp
+++ b/velox/connectors/filesystem/FileSystemConfig.cpp
@@ -186,9 +186,8 @@ const common::CompressionKind FileSystemWriteConfig::getFileCompressionType() {
       compressionKind == common::CompressionKind_SNAPPY ||
           compressionKind == common::CompressionKind_LZ4 ||
           compressionKind == common::CompressionKind_ZSTD ||
-          compressionKind == common::CompressionKind_GZIP ||
-          compressionKind == common::CompressionKind_ZLIB,
-      "Unsupported parquet compression codec '{}'. Supported values are none, snappy, lz4 and zstd.",
+          compressionKind == common::CompressionKind_GZIP,
+      "Unsupported parquet compression codec '{}'. Supported values are none, snappy, lz4, gzip and zstd.",
       compression);
   return compressionKind;
 }

--- a/velox/connectors/filesystem/FileSystemConfig.h
+++ b/velox/connectors/filesystem/FileSystemConfig.h
@@ -48,10 +48,14 @@ class FileSystemWriteConfig {
   static constexpr const char* kPartitionTimeExtractPattern =
       "partition.time-extractor.timestamp-pattern";
   static constexpr const char* kFileCompression = "sink.file.compression";
+  static constexpr const char* kFlushOnWrite = "sink.flush-on-write";
   static constexpr const char* kParquetCompressionCodec =
       "parquet.compression-codec";
+  static constexpr const char* kZstdCompressionLevel =
+      "sink.zstd-compression-level";
   /// The default value of max partitions per writer.
   static constexpr const int32_t defaultMaxPartitionsPerWriter = 65535;
+  static constexpr const int32_t defaultZstdCompressionLevel = 3;
   /// The supported file format to write
   const std::unordered_map<std::string, dwio::common::FileFormat>
       supportedFileFormats = {
@@ -78,9 +82,8 @@ class FileSystemWriteConfig {
   const int32_t getPartitionCommitDelayMillis();
   const std::string getPartitionTimeExtractPattern();
   const common::CompressionKind getFileCompressionType();
-  const bool flushOnWrite() {
-    return false;
-  }
+  const int32_t getZstdCompressionLevel();
+  const bool flushOnWrite();
   const bool exists(const std::string& configKey) {
     return config_ && config_->valueExists(configKey);
   }

--- a/velox/connectors/filesystem/FileSystemConfig.h
+++ b/velox/connectors/filesystem/FileSystemConfig.h
@@ -79,7 +79,7 @@ class FileSystemWriteConfig {
   const std::string getPartitionTimeExtractPattern();
   const common::CompressionKind getFileCompressionType();
   const bool flushOnWrite() {
-    return true;
+    return false;
   }
   const bool exists(const std::string& configKey) {
     return config_ && config_->valueExists(configKey);

--- a/velox/connectors/filesystem/FileSystemDataSink.cpp
+++ b/velox/connectors/filesystem/FileSystemDataSink.cpp
@@ -122,8 +122,8 @@ const std::unique_ptr<dwio::common::Writer> FileSystemDataSink::createWriter(
     if (auto* parquetOptions =
             dynamic_cast<parquet::WriterOptions*>(options.get())) {
       if (!parquetOptions->codecOptions) {
-        parquetOptions->codecOptions =
-            std::make_shared<parquet::CodecOptions>(3);
+        parquetOptions->codecOptions = std::make_shared<parquet::CodecOptions>(
+            writeConfig_->getZstdCompressionLevel());
       }
     }
   }
@@ -481,37 +481,30 @@ void FileSystemDataSink::splitInputRowsAndEnsureWriters() {
   }
 }
 
-void FileSystemDataSink::appendData(RowVectorPtr input) {
-  checkRunning();
-  // Write to unpartitioned table.
-  if (!isPartitioned()) {
-    const FsWriterId writerId{0};
-    const auto index = ensureWriter(writerId);
+std::optional<uint32_t> FileSystemDataSink::singlePartitionIdInCurrentBatch()
+    const {
+  if (partitionIds_.empty()) {
+    return std::nullopt;
+  }
+
+  const auto firstPartitionId = partitionIds_[0];
+  for (vector_size_t row = 1; row < partitionIds_.size(); ++row) {
+    if (partitionIds_[row] != firstPartitionId) {
+      return std::nullopt;
+    }
+  }
+
+  VELOX_CHECK_LT(firstPartitionId, std::numeric_limits<uint32_t>::max());
+  return static_cast<uint32_t>(firstPartitionId);
+}
+
+void FileSystemDataSink::writePartitionedInput(RowVectorPtr input) {
+  if (const auto partitionId = singlePartitionIdInCurrentBatch()) {
+    const auto index = ensureWriter(FsWriterId{*partitionId});
     write(index, input);
     return;
   }
-  // Compute partition numbers.
-  computePartitionIds(input);
 
-  // Lazy load all the input columns.
-  for (column_index_t i = 0; i < input->childrenSize(); ++i) {
-    input->childAt(i)->loadedVector();
-  }
-  if (!partitionIds_.empty()) {
-    const auto firstPartitionId = partitionIds_[0];
-    bool singlePartition = true;
-    for (vector_size_t row = 1; row < partitionIds_.size(); ++row) {
-      if (partitionIds_[row] != firstPartitionId) {
-        singlePartition = false;
-        break;
-      }
-    }
-    if (singlePartition) {
-      const auto index = ensureWriter(getWriterId(0));
-      write(index, input);
-      return;
-    }
-  }
   // All inputs belong to a single non-bucketed partition. The partition id
   // must be zero.
   if (partitionIdGenerator_->numPartitions() == 1) {
@@ -519,6 +512,7 @@ void FileSystemDataSink::appendData(RowVectorPtr input) {
     write(index, input);
     return;
   }
+
   splitInputRowsAndEnsureWriters();
   for (auto index = 0; index < writers_.size(); ++index) {
     const vector_size_t partitionSize = partitionSizes_[index];
@@ -531,6 +525,27 @@ void FileSystemDataSink::appendData(RowVectorPtr input) {
         : exec::wrap(partitionSize, partitionRows_[index], input);
     write(index, writerInput);
   }
+}
+
+void FileSystemDataSink::appendData(RowVectorPtr input) {
+  checkRunning();
+  // Write to unpartitioned table.
+  if (!isPartitioned()) {
+    const FsWriterId writerId{0};
+    const auto index = ensureWriter(writerId);
+    write(index, input);
+    return;
+  }
+
+  // Compute partition numbers.
+  computePartitionIds(input);
+
+  // Lazy load all the input columns.
+  for (column_index_t i = 0; i < input->childrenSize(); ++i) {
+    input->childAt(i)->loadedVector();
+  }
+
+  writePartitionedInput(input);
 }
 
 void FileSystemDataSink::setState(State newState) {

--- a/velox/connectors/filesystem/FileSystemDataSink.cpp
+++ b/velox/connectors/filesystem/FileSystemDataSink.cpp
@@ -442,11 +442,11 @@ void FileSystemDataSink::splitInputRowsAndEnsureWriters() {
 
   std::fill(partitionSizes_.begin(), partitionSizes_.end(), 0);
 
-  const auto numRows = isPartitioned() ? partitionIds_.size() : 0;
+  const auto partitionIdsSize = isPartitioned() ? partitionIds_.size() : 0;
   std::vector<uint32_t> partitionToWriterIndex(
       partitionIdGenerator_->numPartitions(),
       std::numeric_limits<uint32_t>::max());
-  for (auto row = 0; row < numRows; ++row) {
+  for (auto row = 0; row < partitionIdsSize; ++row) {
     const auto partitionId = partitionIds_[row];
     VELOX_CHECK_LT(partitionId, partitionToWriterIndex.size());
 
@@ -460,8 +460,8 @@ void FileSystemDataSink::splitInputRowsAndEnsureWriters() {
     VELOX_DCHECK_EQ(partitionSizes_.size(), partitionRows_.size());
     VELOX_DCHECK_EQ(partitionRows_.size(), rawPartitionRows_.size());
     if (FOLLY_UNLIKELY(partitionRows_[index] == nullptr) ||
-        (partitionRows_[index]->capacity() < numRows * sizeof(vector_size_t))) {
-      partitionRows_[index] = allocateIndices(numRows, queryCtx_->memoryPool());
+        (partitionRows_[index]->capacity() < partitionIdsSize * sizeof(vector_size_t))) {
+      partitionRows_[index] = allocateIndices(partitionIdsSize, queryCtx_->memoryPool());
       rawPartitionRows_[index] =
           partitionRows_[index]->asMutable<vector_size_t>();
     }

--- a/velox/connectors/filesystem/FileSystemDataSink.cpp
+++ b/velox/connectors/filesystem/FileSystemDataSink.cpp
@@ -25,6 +25,7 @@
 #include "velox/dwio/catalog/fbhive/FileUtils.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/Options.h"
+#include "velox/dwio/parquet/writer/Writer.h"
 #include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::connector::filesystem {
@@ -115,6 +116,15 @@ const std::unique_ptr<dwio::common::Writer> FileSystemDataSink::createWriter(
 
   if (!options->compressionKind) {
     options->compressionKind = writeConfig_->getFileCompressionType();
+  }
+
+  if (options->compressionKind == common::CompressionKind_ZSTD) {
+    if (auto* parquetOptions =
+            dynamic_cast<parquet::WriterOptions*>(options.get())) {
+      if (!parquetOptions->codecOptions) {
+        parquetOptions->codecOptions = std::make_shared<parquet::CodecOptions>(3);
+      }
+    }
   }
 
   if (options->nonReclaimableSection == nullptr) {
@@ -433,9 +443,18 @@ void FileSystemDataSink::splitInputRowsAndEnsureWriters() {
   std::fill(partitionSizes_.begin(), partitionSizes_.end(), 0);
 
   const auto numRows = isPartitioned() ? partitionIds_.size() : 0;
+  std::vector<uint32_t> partitionToWriterIndex(
+      partitionIdGenerator_->numPartitions(),
+      std::numeric_limits<uint32_t>::max());
   for (auto row = 0; row < numRows; ++row) {
-    const auto id = getWriterId(row);
-    const uint32_t index = ensureWriter(id);
+    const auto partitionId = partitionIds_[row];
+    VELOX_CHECK_LT(partitionId, partitionToWriterIndex.size());
+
+    auto& index = partitionToWriterIndex[partitionId];
+    if (index == std::numeric_limits<uint32_t>::max()) {
+      VELOX_CHECK_LT(partitionId, std::numeric_limits<uint32_t>::max());
+      index = ensureWriter(FsWriterId{static_cast<uint32_t>(partitionId)});
+    }
 
     VELOX_DCHECK_LT(index, partitionSizes_.size());
     VELOX_DCHECK_EQ(partitionSizes_.size(), partitionRows_.size());
@@ -474,6 +493,21 @@ void FileSystemDataSink::appendData(RowVectorPtr input) {
   // Lazy load all the input columns.
   for (column_index_t i = 0; i < input->childrenSize(); ++i) {
     input->childAt(i)->loadedVector();
+  }
+  if (!partitionIds_.empty()) {
+    const auto firstPartitionId = partitionIds_[0];
+    bool singlePartition = true;
+    for (vector_size_t row = 1; row < partitionIds_.size(); ++row) {
+      if (partitionIds_[row] != firstPartitionId) {
+        singlePartition = false;
+        break;
+      }
+    }
+    if (singlePartition) {
+      const auto index = ensureWriter(getWriterId(0));
+      write(index, input);
+      return;
+    }
   }
   // All inputs belong to a single non-bucketed partition. The partition id
   // must be zero.

--- a/velox/connectors/filesystem/FileSystemDataSink.cpp
+++ b/velox/connectors/filesystem/FileSystemDataSink.cpp
@@ -122,7 +122,8 @@ const std::unique_ptr<dwio::common::Writer> FileSystemDataSink::createWriter(
     if (auto* parquetOptions =
             dynamic_cast<parquet::WriterOptions*>(options.get())) {
       if (!parquetOptions->codecOptions) {
-        parquetOptions->codecOptions = std::make_shared<parquet::CodecOptions>(3);
+        parquetOptions->codecOptions =
+            std::make_shared<parquet::CodecOptions>(3);
       }
     }
   }
@@ -460,8 +461,10 @@ void FileSystemDataSink::splitInputRowsAndEnsureWriters() {
     VELOX_DCHECK_EQ(partitionSizes_.size(), partitionRows_.size());
     VELOX_DCHECK_EQ(partitionRows_.size(), rawPartitionRows_.size());
     if (FOLLY_UNLIKELY(partitionRows_[index] == nullptr) ||
-        (partitionRows_[index]->capacity() < partitionIdsSize * sizeof(vector_size_t))) {
-      partitionRows_[index] = allocateIndices(partitionIdsSize, queryCtx_->memoryPool());
+        (partitionRows_[index]->capacity() <
+         partitionIdsSize * sizeof(vector_size_t))) {
+      partitionRows_[index] =
+          allocateIndices(partitionIdsSize, queryCtx_->memoryPool());
       rawPartitionRows_[index] =
           partitionRows_[index]->asMutable<vector_size_t>();
     }

--- a/velox/connectors/filesystem/FileSystemDataSink.h
+++ b/velox/connectors/filesystem/FileSystemDataSink.h
@@ -318,7 +318,11 @@ class FileSystemDataSink : public DataSink {
   // Compute the partition id for each row in 'input'.
   void computePartitionIds(const RowVectorPtr& input);
 
+  std::optional<uint32_t> singlePartitionIdInCurrentBatch() const;
+
   void splitInputRowsAndEnsureWriters();
+
+  void writePartitionedInput(RowVectorPtr input);
 
   const std::unique_ptr<dwio::common::Writer> createWriter(
       const std::string& writePath,

--- a/velox/connectors/filesystem/tests/FileSystemConnectorTest.cpp
+++ b/velox/connectors/filesystem/tests/FileSystemConnectorTest.cpp
@@ -77,6 +77,10 @@ TEST_F(FileSystemConnectorTest, testWriteConfigDefaults) {
   ASSERT_EQ(writeConfig->getPartitionTimeExtractPattern(), "");
   ASSERT_EQ(
       writeConfig->getFileCompressionType(), common::CompressionKind_NONE);
+  ASSERT_EQ(
+      writeConfig->getZstdCompressionLevel(),
+      FileSystemWriteConfig::defaultZstdCompressionLevel);
+  ASSERT_FALSE(writeConfig->flushOnWrite());
 }
 
 TEST_F(FileSystemConnectorTest, testWriteConfigValues) {
@@ -89,7 +93,9 @@ TEST_F(FileSystemConnectorTest, testWriteConfigValues) {
       {FileSystemWriteConfig::kPartitionCommitPolicy, "success-file"},
       {FileSystemWriteConfig::kPartitionCommitDelay, "3 sec"},
       {FileSystemWriteConfig::kPartitionTimeExtractPattern, "$dt $hour:00:00"},
+      {FileSystemWriteConfig::kFlushOnWrite, "true"},
       {FileSystemWriteConfig::kParquetCompressionCodec, "snappy"},
+      {FileSystemWriteConfig::kZstdCompressionLevel, "7"},
   });
 
   ASSERT_EQ(writeConfig->getPath(), "file:///tmp/filesystem_sink");
@@ -100,6 +106,8 @@ TEST_F(FileSystemConnectorTest, testWriteConfigValues) {
   ASSERT_EQ(writeConfig->getPartitionCommitPolicy(), "success-file");
   ASSERT_EQ(writeConfig->getPartitionCommitDelayMillis(), 3'000);
   ASSERT_EQ(writeConfig->getPartitionTimeExtractPattern(), "$dt $hour:00:00");
+  ASSERT_TRUE(writeConfig->flushOnWrite());
+  ASSERT_EQ(writeConfig->getZstdCompressionLevel(), 7);
   ASSERT_EQ(
       writeConfig->getFileCompressionType(), common::CompressionKind_SNAPPY);
 }
@@ -177,10 +185,10 @@ TEST_F(FileSystemConnectorTest, testWriteConfigInvalidValues) {
       makeWriteConfig(
           {
               {FileSystemWriteConfig::kFormat, "parquet"},
-              {FileSystemWriteConfig::kParquetCompressionCodec, "gzip"},
+              {FileSystemWriteConfig::kParquetCompressionCodec, "brotli"},
           })
           ->getFileCompressionType(),
-      "Unsupported parquet compression codec 'gzip'");
+      "Not support compression kind brotli");
   VELOX_ASSERT_THROW(
       makeWriteConfig(
           {

--- a/velox/connectors/filesystem/tests/FileSystemConnectorTest.cpp
+++ b/velox/connectors/filesystem/tests/FileSystemConnectorTest.cpp
@@ -215,10 +215,13 @@ TEST_F(FileSystemConnectorTest, testWriteNonPartitionedTable) {
       writerParams.writeDirectory() + "/" + writerParams.writeFileName();
   const std::string targetFilePath =
       writerParams.targetDirectory() + "/" + writerParams.targetFileName();
+  const std::vector<std::string> committed = snapshotAndCommit(fsDataSink, 0);
+  ASSERT_EQ(committed.size(), 1);
+  ASSERT_EQ(committed[0], targetFilePath);
   auto fs_ =
       filesystems::getFileSystem(writeFilePath, fsConnector->connectorConfig());
   ASSERT_TRUE(fs_ != nullptr);
-  fs_->rename(writeFilePath, targetFilePath);
+  ASSERT_FALSE(fs_->exists(writeFilePath));
   ASSERT_TRUE(fs_->exists(targetFilePath));
   std::string localFilePath = targetFilePath.substr(7, targetFilePath.size());
   std::ifstream localFile(localFilePath);
@@ -286,6 +289,7 @@ TEST_F(FileSystemConnectorTest, testWritePartitionedTable) {
         writerParams.writeDirectory() ==
         dataPath + "/" + partitionName.value());
   }
+  fsDataSink->abort();
 }
 
 TEST_F(
@@ -420,6 +424,7 @@ TEST_F(FileSystemConnectorTest, testRestoreLegacyPerBucketPartCounterState) {
       restoredFsDataSink->getWriteInfos()[0]->writerParameters.targetFileName();
   // After restoring max=5, the next part file must use counter 5.
   ASSERT_NE(targetFileName.find("-5"), std::string::npos);
+  restoredFsDataSink->abort();
 }
 
 TEST_F(FileSystemConnectorTest, testNonPartitionedFileCommit) {
@@ -597,6 +602,7 @@ TEST_F(FileSystemConnectorTest, testFileRolling) {
   fsDataSink->appendData(inputData1);
   ASSERT_TRUE(fsDataSink->getWriteInfos().size() == 2);
   ASSERT_TRUE(fsDataSink->getPendingWriterInfosSize() == 2);
+  fsDataSink->abort();
 }
 
 TEST_F(FileSystemConnectorTest, testFileCommit) {


### PR DESCRIPTION
#### Disable flush on write
1. current writer flush data to hdfs frequently, when it append data to memory, the `flush` operation will be executed, which results in higher cpu usage, and  bigger file size.

#### Enable fast partition path
1. when data input batch comes, the writer will iterate row by row to find which partition the row should be written.  In most cases, these inputs are belonged to one partition, so we just check whether this is true, and set partition path quickly.

#### Set zstd compression level to 3
this is aligned with original flink, as velox zstd default compression level is 1.