### PR TITLE
fix: Velox shouldn't crash and should pass the exception to flink 

### DIFF
--- a/velox/connectors/filesystem/FileSystemConnector.cpp
+++ b/velox/connectors/filesystem/FileSystemConnector.cpp
@@ -39,6 +39,9 @@ std::unique_ptr<DataSink> FileSystemConnector::createDataSink(
   std::shared_ptr<FileSystemInsertTableHandle> insertTableHandle =
       std::dynamic_pointer_cast<FileSystemInsertTableHandle>(
           connectorInsertTableHandle);
+  VELOX_CHECK_NOT_NULL(
+      insertTableHandle,
+      "Failed to create filesystem data sink because insert table handle is not a FileSystemInsertTableHandle.");
   const std::unordered_map<std::string, std::string>& tableParams =
       insertTableHandle->tableParameters();
   std::shared_ptr<FileSystemWriteConfig> newWriteConfig =

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.cpp
@@ -48,7 +48,15 @@ HdfsWriteFile::HdfsWriteFile(
 
 HdfsWriteFile::~HdfsWriteFile() {
   if (hdfsFile_) {
-    close();
+    try {
+      close();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to close HDFS file in destructor: " << filePath_
+                 << ", error: " << e.what();
+    } catch (...) {
+      LOG(ERROR) << "Failed to close HDFS file in destructor: " << filePath_
+                 << ", unknown error";
+    }
   }
 }
 

--- a/velox/connectors/kafka/KafkaDataSource.cpp
+++ b/velox/connectors/kafka/KafkaDataSource.cpp
@@ -265,6 +265,9 @@ std::optional<RowVectorPtr> KafkaDataSource::next(
   if (queue_.empty()) {
     // consume the data batch from kafka, and stored the consumed data in the
     // queue.
+    VELOX_CHECK_NOT_NULL(
+        consumer_.get(),
+        "Failed to consume kafka messages as the consumer is null.");
     consumer_->consumeBatch(queue_, consumedMsgBytes);
     consumePos_ = 0;
     // If nothing consumed, return directly.

--- a/velox/connectors/kafka/format/StreamJSONRecordDeserializer.cpp
+++ b/velox/connectors/kafka/format/StreamJSONRecordDeserializer.cpp
@@ -57,7 +57,7 @@ const void KafkaStreamJSONRecordDeserializer::deserialize(
     deserializer_->deserialize(value, index, vec);
   } catch (const std::exception& e) {
     LOG(WARNING) << "Failed to deserialize record: " << message
-                << " , error: " << e.what();
+                 << " , error: " << e.what();
   }
 }
 

--- a/velox/connectors/kafka/format/StreamJSONRecordDeserializer.cpp
+++ b/velox/connectors/kafka/format/StreamJSONRecordDeserializer.cpp
@@ -51,16 +51,13 @@ const void KafkaStreamJSONRecordDeserializer::deserialize(
     const size_t index,
     VectorPtr& vec) {
   try {
-    simdjson::padded_string_view json_padded(
-        message.data(),
-        message.size(),
-        message.size() + simdjson::SIMDJSON_PADDING);
-    simdjson::ondemand::document doc = parser_->iterate(json_padded);
+    simdjson::padded_string jsonPadded(message);
+    simdjson::ondemand::document doc = parser_->iterate(jsonPadded);
     JSONValue value = doc.get_value();
     deserializer_->deserialize(value, index, vec);
   } catch (const std::exception& e) {
     LOG(WARNING) << "Failed to deserialize record: " << message
-                 << " , error: " << e.what();
+                << " , error: " << e.what();
   }
 }
 

--- a/velox/connectors/pulsar/PulsarConsumer.cpp
+++ b/velox/connectors/pulsar/PulsarConsumer.cpp
@@ -100,7 +100,14 @@ PulsarConsumer::PulsarConsumer(
 }
 
 PulsarConsumer::~PulsarConsumer() {
-  close();
+  try {
+    close();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to close Pulsar consumer in destructor: "
+               << e.what();
+  } catch (...) {
+    LOG(ERROR) << "Failed to close Pulsar consumer in destructor: unknown error";
+  }
 }
 
 void PulsarConsumer::close() {

--- a/velox/connectors/pulsar/PulsarConsumer.cpp
+++ b/velox/connectors/pulsar/PulsarConsumer.cpp
@@ -103,10 +103,10 @@ PulsarConsumer::~PulsarConsumer() {
   try {
     close();
   } catch (const std::exception& e) {
-    LOG(ERROR) << "Failed to close Pulsar consumer in destructor: "
-               << e.what();
+    LOG(ERROR) << "Failed to close Pulsar consumer in destructor: " << e.what();
   } catch (...) {
-    LOG(ERROR) << "Failed to close Pulsar consumer in destructor: unknown error";
+    LOG(ERROR)
+        << "Failed to close Pulsar consumer in destructor: unknown error";
   }
 }
 

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -248,17 +248,25 @@ StreamElementPtr StatefulTask::popOutput() {
   return out;
 }
 
-void StatefulTask::finish() {
-  VELOX_CHECK(
-      pendings_.empty(),
-      "Outputs have {} not been consumed before finishing the task. {} {}",
-      pendings_.size(),
-      operatorChain_->detail());
-  operatorChain_->close();
-  // TODO: update operator stats
+void StatefulTask::finish(bool throwException) {
+  if (throwException) {
+    VELOX_CHECK(
+        pendings_.empty(),
+        "Outputs have {} not been consumed before finishing the task. {}",
+        pendings_.size(),
+        operatorChain_ ? operatorChain_->detail() : "<null operator chain>");
+  } else {
+    LOG(ERROR) << "Outputs have {} not been consumed before finishing the task. {}",
+        pendings_.size(),
+        operatorChain_ ? operatorChain_->detail() : "<null operator chain>";
+  }
+  if (operatorChain_) {
+    operatorChain_->close();
+    // TODO: update operator stats
 
-  // remove operators to release memory.
-  operatorChain_.reset();
+    // remove operators to release memory.
+    operatorChain_.reset();
+  }
   driver.reset();
   testingFinish();
 }

--- a/velox/experimental/stateful/StatefulTask.cpp
+++ b/velox/experimental/stateful/StatefulTask.cpp
@@ -256,7 +256,8 @@ void StatefulTask::finish(bool throwException) {
         pendings_.size(),
         operatorChain_ ? operatorChain_->detail() : "<null operator chain>");
   } else {
-    LOG(ERROR) << "Outputs have {} not been consumed before finishing the task. {}",
+    LOG(ERROR)
+        << "Outputs have {} not been consumed before finishing the task. {}",
         pendings_.size(),
         operatorChain_ ? operatorChain_->detail() : "<null operator chain>";
   }

--- a/velox/experimental/stateful/StatefulTask.h
+++ b/velox/experimental/stateful/StatefulTask.h
@@ -89,7 +89,7 @@ class StatefulTask : public exec::Task {
   void init();
 
   // The task is finished, close all operators and reset driver
-  void finish();
+  void finish(bool throwException = true);
 
   // get stats for stateful task.
   exec::TaskStats statefulTaskStats();


### PR DESCRIPTION
related issue: https://github.com/apache/gluten/issues/12208

In some cases, velox backend crash and don't pass the exception to flink side:
- some ptr is used without check, which may lead to `nullptr` crash, this can be found in `FileSystemConnector.cpp` and `KafkaDataSource.cpp`, `insertTableHandle` and `consumer_` may be null;
- some destructor function may throw exception, and it will lead to crash, this may happen in `HdfsWriteFile` and `PulsarConsumer`, and `StatefulTask`'s finish function
- simdjson seralize json string may have out-bound error，and it will also lead to crash