### PR TITLE
feat: EXTRACT supports Date input and adds quarter/isodow/week fields

### DIFF
--- a/velox/experimental/stateful/udf/ExtractDateTime.h
+++ b/velox/experimental/stateful/udf/ExtractDateTime.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 
 #include "velox/functions/Macros.h"
+#include "velox/functions/lib/TimeUtils.h"
 
 #include <algorithm>
 #include <ctime>
@@ -45,6 +46,8 @@ struct ExtractFunction {
       result = timeInfo.tm_year + 1900;
     } else if (fieldLower == "month") {
       result = timeInfo.tm_mon + 1;
+    } else if (fieldLower == "quarter") {
+      result = functions::getQuarter(timeInfo);
     } else if (fieldLower == "day" || fieldLower == "day_of_month") {
       result = timeInfo.tm_mday;
     } else if (fieldLower == "hour") {
@@ -54,13 +57,26 @@ struct ExtractFunction {
     } else if (fieldLower == "second") {
       result = timeInfo.tm_sec;
     } else if (fieldLower == "day_of_week" || fieldLower == "dow") {
-      result = timeInfo.tm_wday == 0 ? 7 : timeInfo.tm_wday;
+      // Flink DAYOFWEEK: Sun=1..Sat=7. tm_wday is Sun=0..Sat=6 so shift +1.
+      result = timeInfo.tm_wday + 1;
+    } else if (fieldLower == "isodow") {
+      // ISO weekday: Mon=1..Sun=7. tm_wday is Sun=0..Sat=6.
+      result = (timeInfo.tm_wday == 0) ? 7 : timeInfo.tm_wday;
     } else if (fieldLower == "day_of_year" || fieldLower == "doy") {
       result = timeInfo.tm_yday + 1;
+    } else if (fieldLower == "week" || fieldLower == "week_of_year") {
+      result = functions::getWeek(timestamp, nullptr, false);
     } else {
       return false;
     }
     return true;
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& result,
+      const arg_type<Varchar>& field,
+      const arg_type<Date>& date) {
+    return call(result, field, Timestamp::fromDate(date));
   }
 };
 

--- a/velox/experimental/stateful/udf/Register.cpp
+++ b/velox/experimental/stateful/udf/Register.cpp
@@ -27,6 +27,8 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "count_char"});
   registerFunction<ExtractFunction, int64_t, Varchar, Timestamp>(
       {prefix + "extract"});
+  registerFunction<ExtractFunction, int64_t, Varchar, Date>(
+      {prefix + "extract"});
   registerFunction<SplitIndexFunction, Varchar, Varchar, Varchar, int64_t>(
       {prefix + "split_index"});
 }

--- a/velox/experimental/stateful/udf/tests/UDFTest.cpp
+++ b/velox/experimental/stateful/udf/tests/UDFTest.cpp
@@ -87,8 +87,9 @@ TEST_F(UDFTest, extractAllFields) {
       {"hour", "HOUR", "Hour", 9},
       {"minute", "MINUTE", "Minute", 40},
       {"second", "SECOND", "Second", 30},
-      {"day_of_week", "DAY_OF_WEEK", "Day_Of_Week", 1},
-      {"dow", "DOW", "Dow", 1},
+      {"day_of_week", "DAY_OF_WEEK", "Day_Of_Week", 2},
+      {"dow", "DOW", "Dow", 2},
+      {"isodow", "ISODOW", "IsoDow", 1},
       {"day_of_year", "DAY_OF_YEAR", "Day_Of_Year", 159},
       {"doy", "DOY", "Doy", 159},
   };
@@ -102,10 +103,12 @@ TEST_F(UDFTest, extractAllFields) {
         << "field: " << f.mixed;
   }
 
-  // Sunday: tm_wday=0 returns 7
   auto sunday = Timestamp(kSundayTs, 0);
   for (const auto& name :
        {"day_of_week", "DAY_OF_WEEK", "Day_Of_Week", "dow", "DOW", "Dow"}) {
+    EXPECT_EQ(1, extractField(name, sunday).value()) << "field: " << name;
+  }
+  for (const auto& name : {"isodow", "ISODOW", "IsoDow"}) {
     EXPECT_EQ(7, extractField(name, sunday).value()) << "field: " << name;
   }
 }
@@ -116,6 +119,40 @@ TEST_F(UDFTest, extractUnknownFieldReturnsNull) {
 
   EXPECT_FALSE(extractField("unknown_field", ts).has_value());
   EXPECT_FALSE(extractField("UNKNOWN", ts).has_value());
+}
+
+TEST_F(UDFTest, extractFromDate) {
+  stateful::udf::registerFunctions("");
+
+  const int32_t kMondayDate = kMondayTs / 86400;
+
+  // (size, valueAt, ...) overload: ({n}, type) hits the size_t overload via
+  // standard conversion and ends up allocating n uninitialized slots.
+  auto rowVector = makeRowVector({makeFlatVector<int32_t>(
+      1,
+      [kMondayDate](vector_size_t) { return kMondayDate; },
+      nullptr,
+      DATE())});
+
+  const std::vector<std::pair<std::string, int64_t>> fields = {
+      {"year", 2026},
+      {"month", 6},
+      {"quarter", 2},
+      {"day", 8},
+      {"day_of_month", 8},
+      {"day_of_week", 2},
+      {"dow", 2},
+      {"isodow", 1},
+      {"day_of_year", 159},
+      {"doy", 159},
+  };
+
+  for (const auto& [field, expected] : fields) {
+    auto expr = makeExtractExpr(field, DATE());
+    auto result = evaluate(expr, rowVector);
+    EXPECT_EQ(expected, result->asFlatVector<int64_t>()->valueAt(0))
+        << "field: " << field;
+  }
 }
 
 TEST_F(UDFTest, splitIndex) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Extends the `EXTRACT(field FROM x)` UDF under `experimental/stateful` to accept `Date` input and adds the `quarter`, `isodow`, and `week` fields, see #73 

- `ExtractDateTime.h`:
  - New `call(int64_t&, Varchar, Date)` overload that delegates to the Timestamp overload.
  - The Timestamp adds `quarter` / `isodow` / `week` branches. `day_of_week` follows Flink `DAYOFWEEK` semantics (Sun=1..Sat=7, i.e. `tm_wday + 1`) and `isodow` follows ISO 8601 (Mon=1..Sun=7). The Sunday boundary (`tm_wday == 0`) is the only case where the two diverge, and is explicitly covered by `extractAllFields`.
- `Register.cpp`: registers `extract(int64_t, Varchar, Date)` in the stateful UDF namespace.
- `UDFTest.cpp`: covers the Date overload across all fields, including the Sunday (`tm_wday == 0`) boundary.

## How was this patch tested?

New/extended cases in `velox/experimental/stateful/udf/tests/UDFTest.cpp`:

- `extractAllFields`: validates every field against a fixed timestamp (`2024-03-15 10:30:45 UTC`).
- `extractFromDate`: validates every field against the same calendar date through the Date overload.
- Sunday assertions (`DAYOFWEEK = 1`, `isodow = 7`) cover the `tm_wday == 0` branch.

The Date vector is built explicitly via `makeFlatVector<int32_t>(size, valueAt, isNullAt, DATE())` to avoid the braced-init-list vs `size_t` overload ambiguity.

### E2E differential validation

The fields added/modified by this PR were validated against native Flink by feeding the same nexmark `bid` events through both backends and diffing print-sink outputs row-by-row.

```sql
-- covers QUARTER and WEEK
SELECT `dateTime`,
       YEAR(`dateTime`), MONTH(`dateTime`), DAYOFMONTH(`dateTime`),
       DAYOFYEAR(`dateTime`), DAYOFWEEK(`dateTime`), QUARTER(`dateTime`),
       HOUR(`dateTime`), MINUTE(`dateTime`), SECOND(`dateTime`), WEEK(`dateTime`)
FROM bid;

-- covers DOW and ISODOW (the Sunday boundary tm_wday == 0 is the divergent point)
SELECT `dateTime`,
       EXTRACT(DOW FROM `dateTime`),
       EXTRACT(ISODOW FROM `dateTime`)
FROM bid;
```

- 10-field projection 
- DOW/ISODOW projection: Thursday 2026-07-30 → `DOW=5`, `ISODOW=4`. 
